### PR TITLE
Fix sync-driven Pi skill refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-03-02
+
+### Changed
+
+- `--force` now does a full rebuild: clears plugin cache AND re-converts all targets
+- `--force-convert` remains available for conversion-only rebuilds
+
 ## [0.4.1] - 2026-03-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-03-01
+
+### Fixed
+
+- Pi skill frontmatter `name` now matches directory name (Pi requires this)
+
 ## [0.4.0] - 2026-03-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ai-config sync --force-convert` now falls back to local marketplace source paths when Claude's cached plugin `installPath` is stale or missing, so Pi/Codex/OpenCode conversions refresh after cache clears.
+- Sync-driven conversion errors from conversion reports are now surfaced in sync output instead of being silently ignored.
+- `ai-config convert --dry-run --scope user -t pi` now previews Pi user-scope paths under `~/.pi/agent/` instead of project-scope `~/.pi/` paths.
+
 ## [0.4.2] - 2026-03-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -235,26 +235,18 @@ Skills, commands, hooks, and MCP servers are mapped to each tool's native format
 
 ## Troubleshooting
 
-**Plugin installed but not showing up in / commands**
-
-Clear the plugin cache and re-sync:
+**Something not working? Force a full rebuild:**
 
 ```bash
 ai-config sync --force
 ```
 
-**Added a new conversion target but nothing happened**
+This clears the plugin cache and re-converts everything from scratch. Use it when plugins aren't showing up, you've added a new conversion target, or things are just out of sync.
 
-Conversion caches results by content hash. Force re-conversion:
+If you only want to redo conversions without clearing the plugin cache:
 
 ```bash
 ai-config sync --force-convert
-```
-
-**Full clean rebuild** (clear plugin cache + re-convert everything):
-
-```bash
-ai-config sync --force --force-convert
 ```
 
 **Something's broken and Claude Code won't help**

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,8 +64,8 @@ ai-config sync
 |--------|-------------|
 | `-c, --config PATH` | Path to config file |
 | `--dry-run` | Show what would change without doing it |
-| `--fresh` | Clear cache before syncing |
-| `--force-convert` | Force conversion even if sources appear unchanged |
+| `--fresh`, `--force` | Full rebuild: clear cache + reconvert everything |
+| `--force-convert` | Reconvert only (without clearing plugin cache) |
 | `--verify` | Verify sync state after completion |
 
 What it does:

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -132,13 +132,19 @@ This checks that the converted files have valid structure, required fields, and 
 
 ## Conversion Cache
 
-Sync-driven conversion uses content hashing to skip re-conversion when plugin sources haven't changed. To force re-conversion:
+Sync-driven conversion uses content hashing to skip re-conversion when plugin sources haven't changed.
+
+`--force` does a full rebuild (clears plugin cache + re-converts everything):
+
+```bash
+ai-config sync --force
+```
+
+`--force-convert` re-converts without clearing the plugin cache (useful after adding a new target or updating the converter):
 
 ```bash
 ai-config sync --force-convert
 ```
-
-This is useful after updating the converter itself or when you want to regenerate output regardless of source changes.
 
 ## Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-config-cli"
-version = "0.4.1"
+version = "0.4.2"
 description = "Declarative plugin manager for Claude Code"
 authors = [
     { name = "Alex Furrier", email = "afurrier@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-config-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "Declarative plugin manager for Claude Code"
 authors = [
     { name = "Alex Furrier", email = "afurrier@gmail.com" }

--- a/src/ai_config/cli.py
+++ b/src/ai_config/cli.py
@@ -85,7 +85,8 @@ def main() -> None:
     "  ai-config sync --dry-run        Preview changes before applying\n"
     "  ai-config sync                  Apply changes\n"
     "  ai-config sync --verify         Apply and verify result\n"
-    "  ai-config sync --fresh          Clear cache, then sync from scratch",
+    "  ai-config sync --force          Full rebuild: clear cache + reconvert all\n"
+    "  ai-config sync --force-convert   Reconvert only (skip cache clear)",
 )
 @click.option(
     "--config",
@@ -95,11 +96,13 @@ def main() -> None:
     help="Path to config file. Default: auto-detected .ai-config/config.yaml.",
 )
 @click.option("--dry-run", is_flag=True, help="Show what would be done without making changes.")
-@click.option("--fresh", "--force", is_flag=True, help="Clear cache before syncing.")
+@click.option(
+    "--fresh", "--force", is_flag=True, help="Full clean rebuild: clear cache + reconvert all."
+)
 @click.option(
     "--force-convert",
     is_flag=True,
-    help="Force conversion even if sources appear unchanged.",
+    help="Force conversion only (without clearing plugin cache).",
 )
 @click.option("--verify", is_flag=True, help="Verify installed state matches config after sync.")
 def sync(
@@ -129,6 +132,10 @@ def sync(
         for error in ref_errors:
             error_console.print(f"  {SYMBOLS['bullet']} {error}")
         sys.exit(1)
+
+    # --fresh/--force implies --force-convert (full clean rebuild)
+    if fresh:
+        force_convert = True
 
     if dry_run:
         console.print("[warning]Dry run mode - no changes will be made[/warning]")

--- a/src/ai_config/cli.py
+++ b/src/ai_config/cli.py
@@ -847,7 +847,11 @@ def convert(
         )
         console.print()
         preview = preview_conversion(
-            plugin_path, target_list, output_dir, commands_as_skills=commands_as_skills
+            plugin_path,
+            target_list,
+            output_dir,
+            scope=install_scope,
+            commands_as_skills=commands_as_skills,
         )
         console.print(preview)
         return

--- a/src/ai_config/converters/convert.py
+++ b/src/ai_config/converters/convert.py
@@ -197,6 +197,7 @@ def preview_conversion(
     plugin_path: Path | str,
     targets: list[str] | list[TargetTool],
     output_dir: Path | str | None = None,
+    scope: InstallScope = InstallScope.PROJECT,
     commands_as_skills: bool = False,
 ) -> str:
     """Preview what conversion would produce without writing files.
@@ -205,6 +206,7 @@ def preview_conversion(
         plugin_path: Path to the Claude plugin directory
         targets: List of target tools
         output_dir: Optional output directory for path display
+        scope: Installation scope to preview
         commands_as_skills: For Codex, convert commands to skills instead of prompts.
 
     Returns:
@@ -240,7 +242,7 @@ def preview_conversion(
         lines.append("")
 
         try:
-            emitter = get_emitter(target, commands_as_skills=commands_as_skills)
+            emitter = get_emitter(target, scope=scope, commands_as_skills=commands_as_skills)
             result = emitter.emit(ir)
             lines.append(result.preview(output_dir if output_dir is None else Path(output_dir)))
         except Exception as e:

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -87,6 +87,44 @@ def _compute_plugin_hash(plugin_path: Path) -> str | None:
         return None
 
 
+def _resolve_local_marketplace_plugin_path(
+    marketplace_root: Path,
+    plugin_name: str,
+) -> Path | None:
+    """Resolve a plugin path from a local marketplace manifest."""
+    for manifest_path in (
+        marketplace_root / ".claude-plugin" / "marketplace.json",
+        marketplace_root / "marketplace.json",
+    ):
+        if not manifest_path.is_file():
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        plugins = manifest.get("plugins", [])
+        if not isinstance(plugins, list):
+            continue
+        for entry in plugins:
+            if not isinstance(entry, dict) or entry.get("name") != plugin_name:
+                continue
+            source = entry.get("source")
+            if not isinstance(source, str):
+                continue
+            source_path = Path(source).expanduser()
+            if not source_path.is_absolute():
+                source_path = marketplace_root / source_path
+            if source_path.is_dir():
+                return source_path.resolve()
+
+    fallback_path = marketplace_root / plugin_name
+    if fallback_path.is_dir():
+        return fallback_path
+
+    return None
+
+
 def _resolve_plugin_conversion_path(
     config: ClaudeTargetConfig,
     plugin_config: PluginConfig,
@@ -110,11 +148,7 @@ def _resolve_plugin_conversion_path(
     if marketplace is None or marketplace.source != PluginSource.LOCAL:
         return installed_path
 
-    source_path = Path(marketplace.path) / plugin_config.plugin_name
-    if source_path.is_dir():
-        return source_path
-
-    return None
+    return _resolve_local_marketplace_plugin_path(Path(marketplace.path), plugin_config.plugin_name)
 
 
 def _sync_marketplaces(

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -13,6 +13,7 @@ from ai_config.types import (
     AIConfig,
     ClaudeTargetConfig,
     ConversionConfig,
+    PluginConfig,
     PluginSource,
     PluginStatus,
     StatusResult,
@@ -67,6 +68,9 @@ def _conversion_signature(conversion: ConversionConfig, output_dir: Path) -> str
 
 def _compute_plugin_hash(plugin_path: Path) -> str | None:
     """Compute a hash of all files in a plugin directory."""
+    if not plugin_path.is_dir():
+        return None
+
     hasher = hashlib.sha256()
     try:
         for file_path in sorted(plugin_path.rglob("*")):
@@ -81,6 +85,36 @@ def _compute_plugin_hash(plugin_path: Path) -> str | None:
         return hasher.hexdigest()
     except OSError:
         return None
+
+
+def _resolve_plugin_conversion_path(
+    config: ClaudeTargetConfig,
+    plugin_config: PluginConfig,
+    installed: claude.InstalledPlugin,
+) -> Path | None:
+    """Resolve the source path to use for cross-tool conversion.
+
+    Claude plugin list can report an installPath under its plugin cache even
+    after that cache was cleared. Prefer a live installPath, but fall back to
+    the configured local marketplace source path when possible.
+    """
+    installed_path = Path(installed.install_path) if installed.install_path else None
+    if installed_path is not None and installed_path.is_dir():
+        return installed_path
+
+    marketplace_name = plugin_config.marketplace
+    if marketplace_name is None:
+        return installed_path
+
+    marketplace = config.marketplaces.get(marketplace_name)
+    if marketplace is None or marketplace.source != PluginSource.LOCAL:
+        return installed_path
+
+    source_path = Path(marketplace.path) / plugin_config.plugin_name
+    if source_path.is_dir():
+        return source_path
+
+    return None
 
 
 def _sync_marketplaces(
@@ -312,7 +346,15 @@ def _sync_conversions(
         installed = installed_by_id.get(plugin_config.id)
         if not installed:
             continue
-        plugin_path = Path(installed.install_path)
+        plugin_path = _resolve_plugin_conversion_path(config, plugin_config, installed)
+        if plugin_path is None:
+            install_path = installed.install_path or "<missing>"
+            errors.append(
+                f"Conversion skipped for {plugin_config.id}: plugin source path not found "
+                f"(installPath={install_path})"
+            )
+            continue
+
         plugin_hash = _compute_plugin_hash(plugin_path)
         if not force_convert and plugin_hash is not None:
             signature_map = cache_entries.get(str(plugin_path), {})
@@ -330,14 +372,25 @@ def _sync_conversions(
                 best_effort=True,
                 commands_as_skills=conversion.commands_as_skills,
             )
+            report_errors = [
+                f"{target.value}: {diagnostic.message}"
+                for target, report in reports.items()
+                for diagnostic in report.errors
+            ]
+            if report_errors:
+                errors.extend(
+                    f"Conversion failed for {plugin_config.id}: {message}"
+                    for message in report_errors
+                )
+                continue
+
             if not dry_run and plugin_hash is not None:
-                if not any(report.has_errors() for report in reports.values()):
-                    signature_map = cache_entries.setdefault(str(plugin_path), {})
-                    signature_map[signature] = {
-                        "hash": plugin_hash,
-                        "updated_at": datetime.now(timezone.utc).isoformat(),
-                    }
-                    cache_dirty = True
+                signature_map = cache_entries.setdefault(str(plugin_path), {})
+                signature_map[signature] = {
+                    "hash": plugin_hash,
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }
+                cache_dirty = True
         except Exception as e:
             errors.append(f"Conversion failed for {plugin_config.id}: {e}")
 

--- a/tests/integration/test_watch_integration.py
+++ b/tests/integration/test_watch_integration.py
@@ -109,8 +109,8 @@ class TestWatchLoop:
         )
         thread.start()
 
-        # Give watchdog time to set up (longer for parallel test runs)
-        time.sleep(1.0)
+        # Give watchdog time to set up (macOS FSEvents can be slow on tmp dirs)
+        time.sleep(2.0)
 
         # Modify the config file
         with open(config_path, "a") as f:

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -18,11 +18,11 @@ from ai_config.converters.ir import (
     BinaryFile,
     InstallScope,
     LspServer,
+    MappingStatus,
     McpServer,
     McpTransport,
     PluginIdentity,
     PluginIR,
-    MappingStatus,
     Skill,
     TargetTool,
     TextFile,
@@ -953,6 +953,18 @@ class TestPreviewConversion:
         )
 
         assert str(tmp_path) in preview or ".codex" in preview
+
+    def test_preview_respects_user_scope_for_pi(self, tmp_path: Path) -> None:
+        """Pi user-scope preview should show ~/.pi/agent paths, not ~/.pi paths."""
+        preview = preview_conversion(
+            FIXTURES_DIR / "complete-plugin",
+            [TargetTool.PI],
+            output_dir=tmp_path,
+            scope=InstallScope.USER,
+        )
+
+        assert str(tmp_path / ".pi" / "agent" / "skills") in preview
+        assert str(tmp_path / ".pi" / "skills") not in preview
 
 
 class TestBestEffort:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -67,7 +67,7 @@ class TestMainGroup:
         """Shows version info."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.4.0" in result.output
+        assert "0.4.1" in result.output
 
     def test_help(self, runner: CliRunner) -> None:
         """Shows help text."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -67,7 +67,7 @@ class TestMainGroup:
         """Shows version info."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.4.1" in result.output
+        assert "0.4.2" in result.output
 
     def test_help(self, runner: CliRunner) -> None:
         """Shows help text."""

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from ai_config.adapters.claude import CommandResult, InstalledMarketplace, InstalledPlugin
-from ai_config.converters.ir import PluginIdentity, TargetTool
+from ai_config.converters.ir import Diagnostic, PluginIdentity, Severity, TargetTool
 from ai_config.converters.report import ConversionReport
 from ai_config.operations import (
     _conversion_signature,
@@ -406,6 +406,171 @@ class TestSyncTarget:
             assert "entries" in saved_cache
             assert str(plugin_path) in saved_cache["entries"]
             assert signature in saved_cache["entries"][str(plugin_path)]
+
+    def test_sync_conversion_uses_local_marketplace_when_install_path_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Conversion falls back to local marketplace source when Claude cache path is stale."""
+        plugin_dir = tmp_path / "marketplace" / "plugin1"
+        plugin_dir.mkdir(parents=True)
+        conversion = ConversionConfig(
+            enabled=True,
+            targets=("pi",),
+            scope="user",
+            output_dir=None,
+        )
+        target_config = ClaudeTargetConfig(
+            marketplaces={
+                "my-marketplace": MarketplaceConfig(
+                    source=PluginSource.LOCAL,
+                    path=str(tmp_path / "marketplace"),
+                )
+            },
+            plugins=(PluginConfig(id="plugin1@my-marketplace", scope="user", enabled=True),),
+            conversion=conversion,
+        )
+        target = TargetConfig(type="claude", config=target_config)
+        installed_plugins = [
+            InstalledPlugin(
+                id="plugin1@my-marketplace",
+                version="1.0.0",
+                scope="user",
+                enabled=True,
+                install_path=str(tmp_path / "missing-cache"),
+            )
+        ]
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        with (
+            patch(
+                "ai_config.operations.claude.list_installed_plugins",
+                return_value=(installed_plugins, []),
+            ),
+            patch(
+                "ai_config.operations.claude.list_installed_marketplaces",
+                return_value=(
+                    [
+                        InstalledMarketplace(
+                            name="my-marketplace",
+                            source=PluginSource.LOCAL,
+                            repo=str(tmp_path / "marketplace"),
+                            install_location=str(tmp_path / "marketplace"),
+                        )
+                    ],
+                    [],
+                ),
+            ),
+            patch("ai_config.operations._load_conversion_cache", return_value={"version": 1, "entries": {}}),
+            patch("ai_config.operations.convert_plugin") as mock_convert,
+        ):
+            result = sync_target(target, force_convert=True)
+
+            assert result.success is True
+            assert result.errors == []
+            assert mock_convert.call_args.kwargs["plugin_path"] == plugin_dir
+
+    def test_sync_conversion_reports_missing_plugin_source(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Missing installPath/local source produces a visible sync error."""
+        conversion = ConversionConfig(
+            enabled=True,
+            targets=("pi",),
+            scope="user",
+            output_dir=None,
+        )
+        target_config = ClaudeTargetConfig(
+            marketplaces={
+                "my-marketplace": MarketplaceConfig(
+                    source=PluginSource.LOCAL,
+                    path=str(tmp_path / "marketplace"),
+                )
+            },
+            plugins=(PluginConfig(id="plugin1@my-marketplace", scope="user", enabled=True),),
+            conversion=conversion,
+        )
+        target = TargetConfig(type="claude", config=target_config)
+        installed_plugins = [
+            InstalledPlugin(
+                id="plugin1@my-marketplace",
+                version="1.0.0",
+                scope="user",
+                enabled=True,
+                install_path=str(tmp_path / "missing-cache"),
+            )
+        ]
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        with (
+            patch(
+                "ai_config.operations.claude.list_installed_plugins",
+                return_value=(installed_plugins, []),
+            ),
+            patch(
+                "ai_config.operations.claude.list_installed_marketplaces",
+                return_value=([], []),
+            ),
+            patch("ai_config.operations._load_conversion_cache", return_value={"version": 1, "entries": {}}),
+            patch("ai_config.operations.convert_plugin") as mock_convert,
+        ):
+            result = sync_target(target, force_convert=True)
+
+            assert result.success is False
+            assert any("plugin source path not found" in error for error in result.errors)
+            mock_convert.assert_not_called()
+
+    def test_sync_conversion_reports_conversion_diagnostics(
+        self,
+        mock_installed_plugins: list[InstalledPlugin],
+        mock_installed_marketplaces: list[InstalledMarketplace],
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Conversion report errors are surfaced in sync output."""
+        conversion = ConversionConfig(
+            enabled=True,
+            targets=("pi",),
+            scope="user",
+            output_dir=None,
+        )
+        target_config = ClaudeTargetConfig(
+            marketplaces={"my-marketplace": MarketplaceConfig(source=PluginSource.GITHUB, repo="owner/repo")},
+            plugins=(PluginConfig(id="plugin1@my-marketplace", scope="user", enabled=True),),
+            conversion=conversion,
+        )
+        target = TargetConfig(type="claude", config=target_config)
+        identity = PluginIdentity(plugin_id="plugin1", name="plugin1", version="1.0.0")
+        report = ConversionReport(source_plugin=identity, target_tool=TargetTool.PI)
+        report.add_diagnostic(
+            Diagnostic(severity=Severity.ERROR, message="Could not find plugin.json manifest")
+        )
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        with (
+            patch(
+                "ai_config.operations.claude.list_installed_plugins",
+                return_value=(mock_installed_plugins, []),
+            ),
+            patch(
+                "ai_config.operations.claude.list_installed_marketplaces",
+                return_value=(mock_installed_marketplaces, []),
+            ),
+            patch("ai_config.operations._load_conversion_cache", return_value={"version": 1, "entries": {}}),
+            patch("ai_config.operations._compute_plugin_hash", return_value="abc123"),
+            patch("ai_config.operations.convert_plugin", return_value={TargetTool.PI: report}),
+        ):
+            result = sync_target(target, force_convert=True)
+
+            assert result.success is False
+            assert any("Could not find plugin.json manifest" in error for error in result.errors)
+
     def test_sync_skips_conversion_when_disabled(
         self,
         mock_installed_plugins: list[InstalledPlugin],

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -472,6 +472,76 @@ class TestSyncTarget:
             assert result.errors == []
             assert mock_convert.call_args.kwargs["plugin_path"] == plugin_dir
 
+    def test_sync_conversion_uses_local_marketplace_manifest_source(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Local fallback respects marketplace.json source paths."""
+        marketplace_dir = tmp_path / "marketplace"
+        plugin_dir = marketplace_dir / "plugins" / "plugin-source"
+        plugin_dir.mkdir(parents=True)
+        (marketplace_dir / ".claude-plugin").mkdir()
+        (marketplace_dir / ".claude-plugin" / "marketplace.json").write_text(
+            '{"name":"my-marketplace","plugins":[{"name":"plugin1","source":"./plugins/plugin-source"}]}'
+        )
+        conversion = ConversionConfig(
+            enabled=True,
+            targets=("pi",),
+            scope="user",
+            output_dir=None,
+        )
+        target_config = ClaudeTargetConfig(
+            marketplaces={
+                "my-marketplace": MarketplaceConfig(
+                    source=PluginSource.LOCAL,
+                    path=str(marketplace_dir),
+                )
+            },
+            plugins=(PluginConfig(id="plugin1@my-marketplace", scope="user", enabled=True),),
+            conversion=conversion,
+        )
+        target = TargetConfig(type="claude", config=target_config)
+        installed_plugins = [
+            InstalledPlugin(
+                id="plugin1@my-marketplace",
+                version="1.0.0",
+                scope="user",
+                enabled=True,
+                install_path=str(tmp_path / "missing-cache"),
+            )
+        ]
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        with (
+            patch(
+                "ai_config.operations.claude.list_installed_plugins",
+                return_value=(installed_plugins, []),
+            ),
+            patch(
+                "ai_config.operations.claude.list_installed_marketplaces",
+                return_value=(
+                    [
+                        InstalledMarketplace(
+                            name="my-marketplace",
+                            source=PluginSource.LOCAL,
+                            repo=str(marketplace_dir),
+                            install_location=str(marketplace_dir),
+                        )
+                    ],
+                    [],
+                ),
+            ),
+            patch("ai_config.operations._load_conversion_cache", return_value={"version": 1, "entries": {}}),
+            patch("ai_config.operations.convert_plugin") as mock_convert,
+        ):
+            result = sync_target(target, force_convert=True)
+
+            assert result.success is True
+            assert result.errors == []
+            assert mock_convert.call_args.kwargs["plugin_path"] == plugin_dir.resolve()
+
     def test_sync_conversion_reports_missing_plugin_source(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ai-config-cli"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ai-config-cli"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- fall back to local marketplace plugin sources when Claude cached plugin installPath is stale or missing
- surface sync-driven conversion report errors instead of silently reporting success
- fix Pi dry-run previews so user-scope conversion shows ~/.pi/agent paths
- includes the local v0.4.1/v0.4.2 commits that were already ahead of origin/main

## Test plan
- [x] uv run ruff check src/ tests/unit/test_operations.py tests/unit/converters/test_conversion.py
- [x] uv run ty check src/
- [x] uv run pytest tests/unit -q
- [x] uv tool install --reinstall .
- [x] cd ~/git_repositories/dots && mise run ai-config:sync
- [x] temporary Pi runtime skill mutation was restored by ai-config:sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
