### PR TITLE
Fix Codex skill output directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex skill conversion now emits to `.codex/skills/` with matching frontmatter names, avoiding duplicate Pi skill discovery from the shared `.agents/skills/` directory.
+
 ## [0.5.0] - 2026-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ targets:
 Run `ai-config sync` and you get:
 
 - **Claude Code**: plugins installed via `claude plugin install`
-- **Codex**: Agent Skills in `~/.agents/skills/`, MCP in `~/.codex/config.toml`, supported hooks in `~/.codex/hooks.json`
+- **Codex**: Agent Skills in `~/.codex/skills/`, MCP in `~/.codex/config.toml`, supported hooks in `~/.codex/hooks.json`
 - **Cursor**: skills in `~/.cursor/skills/`, MCP in `~/.cursor/mcp.json`, hooks in `~/.cursor/hooks.json`
 - **OpenCode**: skills in `~/.opencode/skills/`, MCP in `~/opencode.json`
 - **Pi**: skills in `~/.pi/agent/skills/`, prompt templates in `~/.pi/agent/prompts/`, hook extensions in `~/.pi/agent/extensions/`
@@ -226,7 +226,7 @@ ai-config converts Claude plugins to work with:
 
 | Tool | Output | Binary |
 |------|--------|--------|
-| Codex (OpenAI) | `.agents/skills/` + `.codex/` | `codex` |
+| Codex (OpenAI) | `.codex/skills/` + `.codex/` | `codex` |
 | Cursor | `.cursor/` | `cursor-agent` |
 | OpenCode | `.opencode/` | `opencode` |
 | Pi | `.pi/` | `pi` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -305,7 +305,7 @@ Statuses:
 
 | Component | Claude Code | Codex | Cursor | OpenCode | Pi |
 |-----------|-------------|-------|--------|----------|----|
-| Skill | native (Claude plugin skills) | native (Agent Skills from `.agents/skills`) | native (Agent Skills) | native (Agent Skills + skill tool) | native (Agent Skills) |
+| Skill | native (Claude plugin skills) | native (Agent Skills from `.codex/skills`) | native (Agent Skills) | native (Agent Skills + skill tool) | native (Agent Skills) |
 | Command | native (plugin commands exist, though skills are recommended) | fallback/transform (emit deprecated custom prompts optionally, or skills with `--commands-as-skills`) | native (.cursor/commands) | native (OpenCode supports markdown-backed commands in .opencode/commands/ and ~/.config/opencode/commands/; optionally also supports JSON-defined commands in config). | transform (Pi prompt templates) |
 | Hook | native (Claude hooks in plugin system) | transform (supported command hooks emit to `.codex/hooks.json` with `features.codex_hooks`) | native (Cursor hooks) | emulate (OpenCode has plugins; implement hook-like behavior via plugins if needed, but this spec does not claim a specific hook event API beyond what OpenCode documents as plugin/config extensibility) | emulate (generated TypeScript extension) |
 | MCP server | native (Claude plugin MCP support) | transform (Codex uses `[mcp_servers.*]` in `.codex/config.toml`) | transform (Cursor supports MCP) | native/transform (OpenCode supports MCP; config directory overridable) | unsupported |
@@ -557,7 +557,7 @@ Some validations are inherently TUI-driven (`/` menus, slash commands). tmux can
 
 ## 12) Explicit gaps / TODOs (must be resolved by additional primary research before claiming full automation)
 
-1. **Codex skill discovery is documented**: Codex reads skills from `.agents/skills` in `$HOME` and within repositories (including repo-root and parent-folder scanning), plus `/etc/codex/skills` for admin-installed skills. The remaining "gap" is choosing which of these locations this converter targets by default for each scope (user/project/admin).
+1. **Codex skill discovery is documented**: Codex reads skills from `.codex/skills` in `$HOME` and within repositories. This converter targets `.codex/skills` by default because the generic `.agents/skills` directory is also scanned by other tools such as Pi and can cause duplicate cross-tool skill discovery.
 
 2. **Cursor skills path/version behavior is version-dependent**: Cursor indicates Agent Skills are compatible with Claude Skills format, but rollout/activation can vary (some users report it only enables when `~/.claude/skills` already exists). Do not hardcode user-global paths without primary Cursor docs confirming them; treat as conditional and include a "detection + instructions" step.
 

--- a/ai_agent_docs/conversion-pipeline.md
+++ b/ai_agent_docs/conversion-pipeline.md
@@ -35,7 +35,7 @@ Duck-typed classes sharing the same shape (no explicit Protocol ABC):
 
 | Emitter | Target | Config Format | Env Var Syntax |
 |---------|--------|---------------|----------------|
-| `CodexEmitter` | `.agents/skills/` + `.codex/` | TOML (`config.toml` with `[mcp_servers.*]`) + JSON (`hooks.json`) | `${VAR}` |
+| `CodexEmitter` | `.codex/skills/` + `.codex/` | TOML (`config.toml` with `[mcp_servers.*]`) + JSON (`hooks.json`) | `${VAR}` |
 | `CursorEmitter` | `.cursor/` | JSON (`mcp.json`, `hooks.json`) | `${env:VAR}` |
 | `OpenCodeEmitter` | `.opencode/` | JSON (`opencode.json`, `opencode.lsp.json`) | `{env:VAR}` |
 | `PiEmitter` | `.pi/` or `.pi/agent/` | Markdown skills/prompts + TypeScript extensions | `${VAR}` |

--- a/ai_agent_docs/target-compatibility-baseline.md
+++ b/ai_agent_docs/target-compatibility-baseline.md
@@ -2,8 +2,8 @@
 
 This file records the target-runtime assumptions that ai-config's converter support matrix is based on. Update it when target CLI behavior changes or when refreshing conversion support.
 
-Last checked: 2026-05-08
-Context: PR #12 cross-tool capability refresh
+Last checked: 2026-05-15
+Context: Codex/Pi skill discovery collision refresh
 
 Observed local versions during the Codex/Pi release-note delta pass:
 
@@ -21,7 +21,7 @@ Codex plugin/package distribution is tracked as a follow-up in [issue #13](https
 | Target | Observed support | ai-config output | Runtime validation |
 |---|---|---|---|
 | Claude Code | Native plugin marketplace, skills, hooks, MCP | Source tool, not emitted by converter | `claude plugin validate`, `claude plugin list --json`, `claude mcp list` |
-| Codex | Agent Skills, MCP in `config.toml`, hooks behind `codex_hooks` | `.agents/skills/`, `.codex/config.toml`, `.codex/hooks.json`, prompts | `codex debug prompt-input`, `CODEX_HOME=<generated> codex mcp list` |
+| Codex | Agent Skills, MCP in `config.toml`, hooks behind `codex_hooks` | `.codex/skills/`, `.codex/config.toml`, `.codex/hooks.json`, prompts | `codex debug prompt-input`, `CODEX_HOME=<generated> codex mcp list` |
 | Cursor | Skills, MCP JSON, hooks JSON | `.cursor/skills/`, `.cursor/mcp.json`, `.cursor/hooks.json` | JSON validation, `cursor-agent mcp list` when available |
 | OpenCode | Skills, MCP/config, LSP/config debug surfaces | `.opencode/skills/`, `opencode.json`, `opencode.lsp.json` | `opencode debug skill`, `opencode debug config`, `opencode mcp list` |
 | Pi | Skills, prompt templates, TypeScript extensions | `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/`; user-scope under `.pi/agent/` | RPC `get_commands`, `pi --extension` marker hook |
@@ -57,7 +57,8 @@ claude mcp list 2>&1
 
 ### Codex
 
-- Agent Skills are discovered from `.agents/skills` for project output and `$HOME/.agents/skills` for user output.
+- Agent Skills are discovered from `.codex/skills` for project output and `$HOME/.codex/skills` for user output.
+- Avoid emitting Codex skills into `.agents/skills`: Pi also scans that generic Agent Skills directory, so Codex-only output there creates duplicate Pi skill listings and validation warnings.
 - MCP servers are configured in `.codex/config.toml` under `[mcp_servers.*]`.
 - Supported command hooks can be emitted to `.codex/hooks.json` with `[features].codex_hooks = true`.
 - Shared Codex files must be merged, not clobbered.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -232,7 +232,7 @@ ai-config convert PLUGIN_PATH
 
 Supported targets:
 
-- **codex** — OpenAI Codex (`.agents/skills/` plus `.codex/config.toml`, prompts, and hooks)
+- **codex** — OpenAI Codex (`.codex/skills/` plus `.codex/config.toml`, prompts, and hooks)
 - **cursor** — Cursor (`.cursor/` dir with skills, commands, hooks, and MCP config)
 - **opencode** — OpenCode (`opencode.json` + `.opencode/` skills dir)
 - **pi** — Pi (`.pi/` dir with skills, prompt templates, and extensions)

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -8,7 +8,7 @@ The `convert` command takes a Claude Code plugin directory and produces equivale
 
 | Target | Tool | Output |
 |--------|------|--------|
-| `codex` | OpenAI Codex | `.agents/skills/` plus `.codex/` config, prompts, and hooks |
+| `codex` | OpenAI Codex | `.codex/skills/` plus `.codex/` config, prompts, and hooks |
 | `cursor` | Cursor | `.cursor/` dir with rules + MCP config |
 | `opencode` | OpenCode | `opencode.json` + `.opencode/` skills dir |
 | `pi` | Pi | `.pi/` dir with skills, prompt templates, and extensions |
@@ -70,7 +70,7 @@ With this config, `ai-config sync` installs your Claude plugins and then convert
 |-------|------|---------|-------------|
 | `enabled` | bool | `true` | Enable/disable conversion |
 | `targets` | list | *(required)* | Target tools: `codex`, `cursor`, `opencode`, `pi` |
-| `scope` | string | `"project"` | `"user"` (home dir) or `"project"` (cwd). Codex Agent Skills are discovered from project `.agents/skills`, but Codex MCP/hooks may need user-scope output or manual merge into `CODEX_HOME` depending on runtime trust/config loading. |
+| `scope` | string | `"project"` | `"user"` (home dir) or `"project"` (cwd). Codex Agent Skills are discovered from `.codex/skills`; MCP/hooks may need user-scope output or manual merge into `CODEX_HOME` depending on runtime trust/config loading. |
 | `output_dir` | string | *(auto)* | Custom output directory. Relative paths resolve from config file location |
 | `commands_as_skills` | bool | `false` | Convert commands to skills instead of prompts (Codex-specific) |
 
@@ -80,7 +80,7 @@ How each plugin component maps to target tools:
 
 | Component | Codex | Cursor | OpenCode | Pi |
 |-----------|-------|--------|----------|----|
-| Skills | `.agents/skills/*/SKILL.md` | `.cursor/skills/*/SKILL.md` | `.opencode/skills/*/SKILL.md` | `.pi/skills/*/SKILL.md` or `.pi/agent/skills/*/SKILL.md` |
+| Skills | `.codex/skills/*/SKILL.md` | `.cursor/skills/*/SKILL.md` | `.opencode/skills/*/SKILL.md` | `.pi/skills/*/SKILL.md` or `.pi/agent/skills/*/SKILL.md` |
 | Commands | Prompts or skills | Commands | Prompts | Prompt templates |
 | Hooks | `.codex/hooks.json` + `features.codex_hooks` for supported command hooks | Hooks config | Unsupported | TypeScript extension emulation |
 | MCP servers | `.codex/config.toml` `[mcp_servers.*]` | `.cursor/mcp.json` | `opencode.json` | Unsupported |
@@ -154,7 +154,7 @@ ai-config sync --force-convert
 ai-config convert ./my-plugin --target codex --scope project
 ```
 
-Creates `.agents/skills/` for Codex Agent Skills and `.codex/config.toml` / `.codex/hooks.json` when MCP servers or supported hooks are present. The project-scope `.codex/` files are validated fragments; for active Codex MCP/hook behavior, merge them into the active `CODEX_HOME` or run with an explicit `CODEX_HOME` that points at the generated config.
+Creates `.codex/skills/` for Codex Agent Skills and `.codex/config.toml` / `.codex/hooks.json` when MCP servers or supported hooks are present. The project-scope `.codex/` files are validated fragments; for active Codex MCP/hook behavior, merge them into the active `CODEX_HOME` or run with an explicit `CODEX_HOME` that points at the generated config.
 
 ### Convert to all targets with a report
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ You define your setup once. `ai-config sync` installs your Claude plugins and ge
 ```
 ai-config sync
   → Claude Code: plugins installed
-  → Codex:       ~/.agents/skills/, ~/.codex/config.toml, ~/.codex/hooks.json
+  → Codex:       ~/.codex/skills/, ~/.codex/config.toml, ~/.codex/hooks.json
   → Cursor:      ~/.cursor/skills/, ~/.cursor/mcp.json, ~/.cursor/hooks.json
   → OpenCode:    ~/.opencode/skills/, ~/opencode.json
   → Pi:          ~/.pi/agent/skills/, ~/.pi/agent/prompts/, ~/.pi/agent/extensions/

--- a/src/ai_config/converters/emitters.py
+++ b/src/ai_config/converters/emitters.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import json
 import re
+import shutil
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -74,6 +75,7 @@ class EmitResult:
     files: list[EmittedFile] = field(default_factory=list)
     mappings: list[ComponentMapping] = field(default_factory=list)
     diagnostics: list[Diagnostic] = field(default_factory=list)
+    cleanup_paths: list[Path] = field(default_factory=list)
 
     def add_file(self, path: Path | str, content: str, executable: bool = False) -> None:
         """Add a file to emit."""
@@ -84,6 +86,18 @@ class EmitResult:
         self.files.append(
             EmittedFile(path=Path(path), content=content, binary=True, executable=executable)
         )
+
+    def add_cleanup_path(self, path: Path | str) -> None:
+        """Remove a legacy emitted path before writing new output."""
+        cleanup_path = Path(path)
+        if cleanup_path.is_absolute() or ".." in cleanup_path.parts:
+            self.add_diagnostic(
+                Severity.WARN,
+                f"Ignoring unsafe cleanup path: {cleanup_path}",
+            )
+            return
+        if cleanup_path not in self.cleanup_paths:
+            self.cleanup_paths.append(cleanup_path)
 
     def add_mapping(
         self,
@@ -131,6 +145,14 @@ class EmitResult:
         Returns list of file paths that were/would be written.
         """
         written = []
+        if not dry_run:
+            for cleanup_path in self.cleanup_paths:
+                full_cleanup_path = output_dir / cleanup_path
+                if full_cleanup_path.is_dir() and not full_cleanup_path.is_symlink():
+                    shutil.rmtree(full_cleanup_path)
+                elif full_cleanup_path.exists() or full_cleanup_path.is_symlink():
+                    full_cleanup_path.unlink()
+
         for f in self.files:
             full_path = output_dir / f.path
             if not dry_run:
@@ -480,6 +502,7 @@ class CodexEmitter:
         # frontmatter name must match the output directory.
         content = skill_to_markdown(skill, strip_claude_fields=True, name_override=dir_name)
 
+        result.add_cleanup_path(Path(".agents") / "skills" / dir_name)
         result.add_file(skill_path, content)
 
         # Copy other skill files
@@ -507,6 +530,7 @@ class CodexEmitter:
         By default, commands are emitted as prompts (deprecated but 1:1 with Claude commands).
         With commands_as_skills=True, they're emitted as skills (auto-discoverable).
         """
+        result.add_cleanup_path(Path(".agents") / "skills" / f"{plugin_id}-cmd-{cmd.name}")
         if self.commands_as_skills:
             self._emit_command_as_skill(result, cmd, plugin_id)
         else:

--- a/src/ai_config/converters/emitters.py
+++ b/src/ai_config/converters/emitters.py
@@ -230,20 +230,24 @@ class EmitResult:
 
 
 # Module-level helper function (extracted from BaseEmitter for Protocol pattern)
-def skill_to_markdown(skill: Skill, strip_claude_fields: bool = True) -> str:
+def skill_to_markdown(
+    skill: Skill, strip_claude_fields: bool = True, *, name_override: str | None = None
+) -> str:
     """Convert a skill to SKILL.md format.
 
     Args:
         skill: The skill to convert.
         strip_claude_fields: If True, remove Claude-specific fields like
             allowed-tools, model, context, agent, etc.
+        name_override: Optional emitted Agent Skills name. Use when target tools
+            require frontmatter name to match a namespaced output directory.
 
     Returns:
         Markdown string with YAML frontmatter.
     """
     # Build frontmatter
     meta: dict[str, Any] = {
-        "name": skill.name,
+        "name": name_override or skill.name,
     }
     if skill.description:
         meta["description"] = skill.description
@@ -465,12 +469,16 @@ class CodexEmitter:
 
     def _emit_skill(self, result: EmitResult, skill: Skill, plugin_id: str) -> None:
         """Emit a skill to Codex format."""
-        # Codex uses the Agent Skills standard, discovered from .agents/skills.
-        skill_dir = Path(".agents") / "skills" / f"{plugin_id}-{skill.name}"
+        # Codex uses the Agent Skills standard, discovered from .codex/skills.
+        # Namespace with the plugin id so multiple plugins can provide similarly
+        # named skills without colliding in the user's Codex home.
+        dir_name = f"{plugin_id}-{skill.name}"
+        skill_dir = Path(".codex") / "skills" / dir_name
         skill_path = skill_dir / "SKILL.md"
 
-        # Convert to markdown, stripping Claude-specific fields
-        content = skill_to_markdown(skill, strip_claude_fields=True)
+        # Convert to markdown, stripping Claude-specific fields. Agent Skills
+        # frontmatter name must match the output directory.
+        content = skill_to_markdown(skill, strip_claude_fields=True, name_override=dir_name)
 
         result.add_file(skill_path, content)
 

--- a/src/ai_config/converters/emitters.py
+++ b/src/ai_config/converters/emitters.py
@@ -829,10 +829,11 @@ class CursorEmitter:
 
     def _emit_skill(self, result: EmitResult, skill: Skill, plugin_id: str) -> None:
         """Emit a skill to Cursor format."""
-        skill_dir = Path(".cursor") / "skills" / f"{plugin_id}-{skill.name}"
+        dir_name = f"{plugin_id}-{skill.name}"
+        skill_dir = Path(".cursor") / "skills" / dir_name
         skill_path = skill_dir / "SKILL.md"
 
-        content = skill_to_markdown(skill, strip_claude_fields=True)
+        content = skill_to_markdown(skill, strip_claude_fields=True, name_override=dir_name)
         result.add_file(skill_path, content)
 
         for f in skill.files:
@@ -1048,10 +1049,11 @@ class OpenCodeEmitter:
 
     def _emit_skill(self, result: EmitResult, skill: Skill, plugin_id: str) -> None:
         """Emit a skill to OpenCode format."""
-        skill_dir = Path(".opencode") / "skills" / f"{plugin_id}-{skill.name}"
+        dir_name = f"{plugin_id}-{skill.name}"
+        skill_dir = Path(".opencode") / "skills" / dir_name
         skill_path = skill_dir / "SKILL.md"
 
-        content = skill_to_markdown(skill, strip_claude_fields=True)
+        content = skill_to_markdown(skill, strip_claude_fields=True, name_override=dir_name)
         result.add_file(skill_path, content)
 
         for f in skill.files:

--- a/src/ai_config/converters/emitters.py
+++ b/src/ai_config/converters/emitters.py
@@ -569,7 +569,7 @@ class CodexEmitter:
         """
         # Emit as a skill directory with SKILL.md
         skill_name = f"{plugin_id}-cmd-{cmd.name}"
-        skill_dir = Path(".agents") / "skills" / skill_name
+        skill_dir = Path(".codex") / "skills" / skill_name
         skill_path = skill_dir / "SKILL.md"
 
         # Build SKILL.md with frontmatter

--- a/src/ai_config/init.py
+++ b/src/ai_config/init.py
@@ -200,7 +200,7 @@ class ConversionChoice:
 def _conversion_output_paths(target: str, base_dir: Path, scope: str) -> list[Path]:
     """Display paths that a conversion target writes under a base output directory."""
     if target == "codex":
-        return [base_dir / ".agents" / "skills", base_dir / ".codex"]
+        return [base_dir / ".codex"]
     if target == "pi" and scope == "user":
         return [base_dir / ".pi" / "agent"]
     return [base_dir / f".{target}"]
@@ -710,7 +710,7 @@ def prompt_conversion_targets(
 
     # Sub-steps loop — GO_BACK within these re-prompts conversion, not the caller
     target_choices = [
-        ("codex", "Codex (OpenAI) - .agents/skills + .codex/ config"),
+        ("codex", "Codex (OpenAI) - .codex/ skills, prompts, and config"),
         ("cursor", "Cursor - .cursor/ directory"),
         ("opencode", "OpenCode - .opencode/ directory"),
         ("pi", "Pi - .pi/ skills, prompts, and extensions"),

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -22,7 +22,7 @@ from ai_config.types import (
     TargetConfig,
 )
 
-_CONVERSION_CACHE_VERSION = 1
+_CONVERSION_CACHE_VERSION = 2
 
 
 def _conversion_cache_path() -> Path:

--- a/src/ai_config/validators/target/codex.py
+++ b/src/ai_config/validators/target/codex.py
@@ -37,19 +37,19 @@ class CodexOutputValidator:
     description = "Validates Codex converted output"
 
     def validate_skills(self, output_dir: Path) -> list[ValidationResult]:
-        """Validate Codex Agent Skills in .agents/skills/."""
+        """Validate Codex Agent Skills in .codex/skills/."""
         results: list[ValidationResult] = []
-        skills_dir = output_dir / ".agents" / "skills"
-        legacy_skills_dir = output_dir / ".codex" / "skills"
+        skills_dir = output_dir / ".codex" / "skills"
+        legacy_skills_dir = output_dir / ".agents" / "skills"
 
         if legacy_skills_dir.exists():
             results.append(
                 ValidationResult(
-                    check_name="codex_legacy_skills_dir",
+                    check_name="codex_legacy_agents_skills_dir",
                     status="warn",
-                    message="Found legacy .codex/skills directory",
-                    details="Current Codex discovers Agent Skills from .agents/skills and $HOME/.agents/skills",
-                    fix_hint="Move skills to .agents/skills",
+                    message="Found legacy .agents/skills directory",
+                    details="Codex discovers Agent Skills from .codex/skills and $HOME/.codex/skills; .agents/skills is also scanned by other tools such as Pi.",
+                    fix_hint="Move Codex skills to .codex/skills",
                 )
             )
 

--- a/src/ai_config/validators/target/codex.py
+++ b/src/ai_config/validators/target/codex.py
@@ -507,14 +507,14 @@ class CodexOutputValidator:
         results: list[ValidationResult] = []
 
         codex_dir = output_dir / ".codex"
-        agents_dir = output_dir / ".agents"
-        if not codex_dir.exists() and not agents_dir.exists():
+        legacy_agents_skills_dir = output_dir / ".agents" / "skills"
+        if not codex_dir.exists() and not legacy_agents_skills_dir.exists():
             results.append(
                 ValidationResult(
                     check_name="codex_output_exists",
                     status="warn",
                     message="No Codex output found",
-                    details=f"Expected .agents/ and/or .codex/ in {output_dir}",
+                    details=f"Expected .codex/ in {output_dir}; .agents/skills is recognized only as legacy Codex output",
                 )
             )
             return results

--- a/tests/e2e/MANUAL_VALIDATION.md
+++ b/tests/e2e/MANUAL_VALIDATION.md
@@ -45,7 +45,7 @@ export OPENAI_API_KEY=sk-...
 codex
 
 # Verify skills directory exists
-ls ~/.agents/skills/
+ls ~/.codex/skills/
 ```
 
 **Expected**: Codex starts without errors. Skills directory contains converted skill files.
@@ -78,7 +78,7 @@ After the automated smoke test runs `ai-config sync`, verify the cross-tool outp
 
 ```bash
 # User scope outputs
-ls ~/.agents/skills/       # Codex skills
+ls ~/.codex/skills/       # Codex skills
 ls ~/.cursor/skills/      # Cursor skills
 ls ~/.opencode/skills/    # OpenCode skills
 

--- a/tests/e2e/test_conversion.py
+++ b/tests/e2e/test_conversion.py
@@ -128,14 +128,14 @@ class TestCodexConversion:
         # Check skill directories exist
         exit_code, _ = exec_in_container(
             claude_container,
-            "test -f /tmp/codex-test/.agents/skills/dev-tools-code-review/SKILL.md",
+            "test -f /tmp/codex-test/.codex/skills/dev-tools-code-review/SKILL.md",
         )
         assert exit_code == 0, "SKILL.md not created for code-review"
 
         # Check SKILL.md content
         exit_code, content = exec_in_container(
             claude_container,
-            "cat /tmp/codex-test/.agents/skills/dev-tools-code-review/SKILL.md",
+            "cat /tmp/codex-test/.codex/skills/dev-tools-code-review/SKILL.md",
         )
         assert exit_code == 0
         assert "name:" in content
@@ -418,7 +418,7 @@ class TestBinarySkillAssets:
             claude_container,
             "python - <<'PY'\n"
             "from pathlib import Path\n"
-            "p = Path('/tmp/bin-out/.agents/skills/bin-plugin-bin-skill/asset.bin')\n"
+            "p = Path('/tmp/bin-out/.codex/skills/bin-plugin-bin-skill/asset.bin')\n"
             "print(p.stat().st_size)\n"
             "PY",
         )
@@ -655,7 +655,7 @@ class TestDoctorTargetValidation:
         # Create a broken Codex output directory
         exit_code, _ = exec_in_container(
             claude_container,
-            "rm -rf /tmp/doctor-broken && mkdir -p /tmp/doctor-broken/.agents/skills/broken-skill",
+            "rm -rf /tmp/doctor-broken && mkdir -p /tmp/doctor-broken/.codex/skills/broken-skill",
         )
         # Create skill directory without SKILL.md
         assert exit_code == 0

--- a/tests/e2e/test_integration_smoke.py
+++ b/tests/e2e/test_integration_smoke.py
@@ -45,8 +45,8 @@ class TestIntegrationSmoke:
         """Verify key output files from conversion."""
         checks = [
             # Codex
-            ("test -d /tmp/smoke-codex/.agents/skills", "Codex Agent Skills dir"),
-            ("ls /tmp/smoke-codex/.agents/skills/*/SKILL.md", "Codex Agent Skill SKILL.md"),
+            ("test -d /tmp/smoke-codex/.codex/skills", "Codex Agent Skills dir"),
+            ("ls /tmp/smoke-codex/.codex/skills/*/SKILL.md", "Codex Agent Skill SKILL.md"),
             # Cursor
             ("test -d /tmp/smoke-cursor/.cursor/skills", "Cursor skills dir"),
             ("ls /tmp/smoke-cursor/.cursor/skills/*/SKILL.md", "Cursor SKILL.md"),

--- a/tests/e2e/test_multi_tool.py
+++ b/tests/e2e/test_multi_tool.py
@@ -171,7 +171,7 @@ class TestCodexPlaceholder:
         # Document expected structure (to be implemented)
         expected_structure = """
         Expected Codex config structure:
-        - ~/.agents/skills/  # User Agent Skills discovery directory
+        - ~/.codex/skills/  # User Codex Agent Skills discovery directory
         - ~/.codex/config.toml # Main Codex configuration including MCP servers
         - ~/.codex/hooks.json  # Hooks config when codex_hooks is enabled
         """

--- a/tests/e2e/test_tool_validation.py
+++ b/tests/e2e/test_tool_validation.py
@@ -154,7 +154,7 @@ class TestCodexToolValidation:
     - codex mcp list: List configured MCP servers
     - codex features list: List feature flags
     - Config: ~/.codex/config.toml (TOML format)
-    - Skills: ~/.agents/skills/ directory
+    - Skills: ~/.codex/skills/ directory
     """
 
     def test_codex_version_check(self, all_tools_container: Container) -> None:
@@ -170,7 +170,7 @@ class TestCodexToolValidation:
         assert "codex" in output.lower() or exit_code == 0
 
     def test_codex_skills_directory_recognized(self, all_tools_container: Container) -> None:
-        """Test Codex recognizes skills in .agents/skills/ after conversion."""
+        """Test Codex recognizes skills in .codex/skills/ after conversion."""
         # Convert a test plugin to Codex format
         exit_code, output = exec_in_container(
             all_tools_container,
@@ -182,7 +182,7 @@ class TestCodexToolValidation:
         # Verify skills directory was created
         exit_code, output = exec_in_container(
             all_tools_container,
-            "ls /tmp/codex-test/.agents/skills/",
+            "ls /tmp/codex-test/.codex/skills/",
         )
         assert exit_code == 0, f"Skills directory not created: {output}"
         assert "dev-tools" in output  # Plugin ID should be in skill name
@@ -1002,7 +1002,7 @@ class TestInteractiveCodexSkillDiscovery:
 
         try:
             # Convert plugin to Codex format
-            # Output to /home/testuser so .agents/skills/ gets created at the right location
+            # Output to /home/testuser so .codex/skills/ gets created at the right location
             exit_code, output = exec_in_container(
                 all_tools_container,
                 "uv run ai-config convert tests/fixtures/sample-plugins/complete-plugin "
@@ -1010,10 +1010,10 @@ class TestInteractiveCodexSkillDiscovery:
             )
             assert exit_code == 0, f"Conversion failed: {output}"
 
-            # Verify skills directory exists (emitter creates .agents/skills/ in output dir)
+            # Verify skills directory exists (emitter creates .codex/skills/ in output dir)
             exit_code, output = exec_in_container(
                 all_tools_container,
-                "ls /home/testuser/.agents/skills/",
+                "ls /home/testuser/.codex/skills/",
             )
             assert exit_code == 0, f"Skills directory not created: {output}"
 
@@ -1060,7 +1060,7 @@ class TestInteractiveCodexSkillDiscovery:
             exec_in_container_tmux(
                 all_tools_container,
                 session_name,
-                "ls -la /home/testuser/.agents/skills/",
+                "ls -la /home/testuser/.codex/skills/",
             )
 
             time.sleep(2)
@@ -1072,7 +1072,7 @@ class TestInteractiveCodexSkillDiscovery:
             # Check a specific skill file exists
             exec_in_container(
                 all_tools_container,
-                f"tmux send-keys -t {session_name} 'cat /home/testuser/.agents/skills/dev-tools-code-review/SKILL.md | head -5' Enter",
+                f"tmux send-keys -t {session_name} 'cat /home/testuser/.codex/skills/dev-tools-code-review/SKILL.md | head -5' Enter",
             )
             time.sleep(2)
             output = capture_tmux_pane(all_tools_container, session_name)

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -318,7 +318,7 @@ class TestCodexEmitter:
         assert any("skill" in d.message.lower() for d in cmd_diags)
 
         # Verify skill file was created (not deprecated prompts)
-        skill_dir = tmp_path / ".agents" / "skills" / "dev-tools-cmd-commit"
+        skill_dir = tmp_path / ".codex" / "skills" / "dev-tools-cmd-commit"
         assert skill_dir.exists(), "Command should be emitted as skill directory"
         skill_file = skill_dir / "SKILL.md"
         assert skill_file.exists(), "SKILL.md should exist in skill directory"

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -482,6 +482,7 @@ class TestCursorEmitter:
 
         skill_md = tmp_path / ".cursor" / "skills" / "dev-tools-code-review" / "SKILL.md"
         assert skill_md.exists()
+        assert "name: dev-tools-code-review" in skill_md.read_text()
 
     def test_emit_commands_no_variables(self, ir) -> None:
         """Test that commands lose variable support with warning."""
@@ -571,6 +572,7 @@ class TestOpenCodeEmitter:
 
         skill_md = tmp_path / ".opencode" / "skills" / "dev-tools-code-review" / "SKILL.md"
         assert skill_md.exists()
+        assert "name: dev-tools-code-review" in skill_md.read_text()
 
     def test_emit_commands_with_variables(self, ir, tmp_path: Path) -> None:
         """Test commands transform variables to OpenCode format."""

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -205,6 +205,17 @@ class TestCodexEmitter:
 
     def test_emit_skills(self, ir, tmp_path: Path) -> None:
         """Test emitting skills to Codex format."""
+        legacy_skill_dir = tmp_path / ".agents" / "skills" / "dev-tools-code-review"
+        legacy_skill_dir.mkdir(parents=True)
+        (legacy_skill_dir / "SKILL.md").write_text(
+            "---\nname: code-review\ndescription: stale\n---\n\nStale"
+        )
+        unrelated_skill_dir = tmp_path / ".agents" / "skills" / "user-managed-skill"
+        unrelated_skill_dir.mkdir(parents=True)
+        (unrelated_skill_dir / "SKILL.md").write_text(
+            "---\nname: user-managed-skill\ndescription: keep\n---\n\nKeep"
+        )
+
         emitter = CodexEmitter()
         result = emitter.emit(ir)
 
@@ -228,6 +239,8 @@ class TestCodexEmitter:
         assert content.startswith("---")
         assert "name: dev-tools-code-review" in content
         assert "description:" in content
+        assert not legacy_skill_dir.exists()
+        assert unrelated_skill_dir.exists()
 
         # Claude-specific fields should be stripped
         assert "allowed-tools:" not in content
@@ -303,6 +316,12 @@ class TestCodexEmitter:
 
     def test_emit_commands_as_skills_opt_in(self, ir, tmp_path: Path) -> None:
         """Test that commands emit as skills with --commands-as-skills flag."""
+        legacy_skill_dir = tmp_path / ".agents" / "skills" / "dev-tools-cmd-commit"
+        legacy_skill_dir.mkdir(parents=True)
+        (legacy_skill_dir / "SKILL.md").write_text(
+            "---\nname: dev-tools-cmd-commit\ndescription: stale\n---\n\nStale"
+        )
+
         emitter = CodexEmitter(commands_as_skills=True)
         result = emitter.emit(ir)
         result.write_to(tmp_path)
@@ -326,6 +345,7 @@ class TestCodexEmitter:
         content = skill_file.read_text()
         assert "name:" in content  # Should have frontmatter
         assert "Create a git commit" in content  # Should have command content
+        assert not legacy_skill_dir.exists()
 
     def test_emit_hooks_transform(self, ir, tmp_path: Path) -> None:
         """Test that supported command hooks are converted to Codex hooks."""

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -220,13 +220,13 @@ class TestCodexEmitter:
         result.write_to(tmp_path)
 
         # Check SKILL.md was written correctly
-        skill_md = tmp_path / ".agents" / "skills" / "dev-tools-code-review" / "SKILL.md"
+        skill_md = tmp_path / ".codex" / "skills" / "dev-tools-code-review" / "SKILL.md"
         assert skill_md.exists()
         content = skill_md.read_text()
 
-        # Should have frontmatter
+        # Should have frontmatter matching the Agent Skills directory name
         assert content.startswith("---")
-        assert "name: code-review" in content
+        assert "name: dev-tools-code-review" in content
         assert "description:" in content
 
         # Claude-specific fields should be stripped
@@ -297,7 +297,7 @@ class TestCodexEmitter:
         result = emitter.emit(ir)
         result.write_to(tmp_path)
 
-        emitted = tmp_path / ".agents" / "skills" / "binary-plugin-bin-skill" / "asset.bin"
+        emitted = tmp_path / ".codex" / "skills" / "binary-plugin-bin-skill" / "asset.bin"
         assert emitted.exists()
         assert emitted.read_bytes() == binary_bytes
 
@@ -1105,7 +1105,7 @@ class TestDryRun:
         assert output_dir.exists()
 
         # Files should exist
-        skills_dir = output_dir / ".agents" / "skills"
+        skills_dir = output_dir / ".codex" / "skills"
         assert skills_dir.exists()
 
 

--- a/tests/unit/test_cli_doctor_target.py
+++ b/tests/unit/test_cli_doctor_target.py
@@ -23,8 +23,8 @@ def runner() -> CliRunner:
 @pytest.fixture
 def codex_output_dir(tmp_path: Path) -> Path:
     """Create a valid Codex output directory."""
-    agents_dir = tmp_path / ".agents"
-    skills_dir = agents_dir / "skills" / "my-skill"
+    codex_dir = tmp_path / ".codex"
+    skills_dir = codex_dir / "skills" / "my-skill"
     skills_dir.mkdir(parents=True)
 
     skill_md = skills_dir / "SKILL.md"
@@ -211,7 +211,7 @@ class TestDoctorAllTargets:
     ) -> None:
         """Doctor validates all targets when --target all is specified."""
         # Create minimal valid output for all targets
-        for tool_dir in [".agents", ".cursor", ".opencode"]:
+        for tool_dir in [".codex", ".cursor", ".opencode"]:
             skills_dir = tmp_path / tool_dir / "skills" / "my-skill"
             skills_dir.mkdir(parents=True)
             skill_md = skills_dir / "SKILL.md"

--- a/tests/unit/test_cli_doctor_target.py
+++ b/tests/unit/test_cli_doctor_target.py
@@ -115,7 +115,7 @@ class TestDoctorCodexTarget:
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
         """Doctor fails when skill directory missing SKILL.md."""
-        codex_dir = tmp_path / ".agents" / "skills" / "broken-skill"
+        codex_dir = tmp_path / ".codex" / "skills" / "broken-skill"
         codex_dir.mkdir(parents=True)
         # No SKILL.md file - should fail
 

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -1,5 +1,6 @@
 """Tests for ai_config.operations module."""
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,7 +10,9 @@ from ai_config.adapters.claude import CommandResult, InstalledMarketplace, Insta
 from ai_config.converters.ir import Diagnostic, PluginIdentity, Severity, TargetTool
 from ai_config.converters.report import ConversionReport
 from ai_config.operations import (
+    _CONVERSION_CACHE_VERSION,
     _conversion_signature,
+    _load_conversion_cache,
     get_status,
     sync_config,
     sync_target,
@@ -66,6 +69,28 @@ def mock_installed_marketplaces() -> list[InstalledMarketplace]:
             install_location="/path/to/marketplace",
         ),
     ]
+
+
+class TestConversionCache:
+    """Tests for conversion cache handling."""
+
+    def test_old_conversion_cache_version_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Old cache versions are invalidated after output schema migrations."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        cache_path = tmp_path / "home" / ".ai-config" / "cache" / "conversion-hashes.json"
+        cache_path.parent.mkdir(parents=True)
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "version": _CONVERSION_CACHE_VERSION - 1,
+                    "entries": {"/plugin": {"signature": {"hash": "abc123"}}},
+                }
+            )
+        )
+
+        assert _load_conversion_cache() == {"version": _CONVERSION_CACHE_VERSION, "entries": {}}
 
 
 class TestSyncTarget:

--- a/tests/unit/validators/test_target_validators.py
+++ b/tests/unit/validators/test_target_validators.py
@@ -19,7 +19,7 @@ class TestCodexValidator:
         from ai_config.validators.target.codex import CodexOutputValidator
 
         # Create valid Codex Agent Skills structure
-        skills_dir = tmp_path / ".agents" / "skills" / "my-skill"
+        skills_dir = tmp_path / ".codex" / "skills" / "my-skill"
         skills_dir.mkdir(parents=True)
         (skills_dir / "SKILL.md").write_text(
             "---\nname: my-skill\ndescription: A test skill\n---\n# My Skill"
@@ -38,7 +38,7 @@ class TestCodexValidator:
         from ai_config.validators.target.codex import CodexOutputValidator
 
         # Create directory without SKILL.md
-        skills_dir = tmp_path / ".agents" / "skills" / "my-skill"
+        skills_dir = tmp_path / ".codex" / "skills" / "my-skill"
         skills_dir.mkdir(parents=True)
 
         validator = CodexOutputValidator()
@@ -52,7 +52,7 @@ class TestCodexValidator:
         from ai_config.validators.target.codex import CodexOutputValidator
 
         # Create skill with uppercase name (invalid)
-        skills_dir = tmp_path / ".agents" / "skills" / "MySkill"
+        skills_dir = tmp_path / ".codex" / "skills" / "MySkill"
         skills_dir.mkdir(parents=True)
         (skills_dir / "SKILL.md").write_text(
             "---\nname: MySkill\ndescription: Invalid name\n---\n# Bad"


### PR DESCRIPTION
## Summary
- Move Codex skill emission from the shared `.agents/skills/` directory to Codex-owned `.codex/skills/`.
- Ensure generated Codex `SKILL.md` frontmatter names match their namespaced output directories.
- Update Codex output validation, init/help text, docs, changelog, and tests to treat `.agents/skills/` as legacy/shared output.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ty check src/`
- [x] `uv run pytest tests/unit/ -q`
- [x] Manual conversion smoke: generated `.codex/skills/dev-tools-code-review/SKILL.md`, confirmed no `.agents/skills`, and confirmed `codex debug prompt-input` discovers the generated skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safurrier/ai-config/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->