### PR TITLE
Add target-native conversion overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Target-native conversion files under `targets/<target>/...` are copied into converted output, allowing plugins to ship tool-specific files that override generated output when needed.
+
 ### Fixed
 
 - Codex skill conversion now emits to `.codex/skills/` with matching frontmatter names, avoiding duplicate Pi skill discovery from the shared `.agents/skills/` directory.

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -64,6 +64,28 @@ targets:
 
 With this config, `ai-config sync` installs your Claude plugins and then converts them to Codex and Cursor format.
 
+## Target-Native Files
+
+Most plugin content should flow through the normal converter. When a target needs hand-written files that cannot be generated cleanly, place them under `targets/<target>/` in the plugin source:
+
+```text
+my-plugin/
+├── .claude-plugin/plugin.json
+├── skills/my-skill/SKILL.md
+└── targets/pi/extensions/my-plugin-hooks.ts
+```
+
+Target-native files are copied into that target's generated output using the target's natural config root. For example, with Pi user scope:
+
+```text
+targets/pi/extensions/my-plugin-hooks.ts
+  -> ~/.pi/agent/extensions/my-plugin-hooks.ts
+```
+
+With Pi project scope, the same source file writes to `.pi/extensions/my-plugin-hooks.ts`.
+
+If a target-native file has the same output path as generated converter output, the target-native file wins over the generated file and the conversion report records the override. Existing target-specific write behavior still applies when writing to disk; for example, Codex `config.toml` and `hooks.json` outputs are merged with existing local config instead of clobbering it. Use target-native files for target-specific glue such as custom Pi TypeScript extensions; prefer generated output for ordinary skills, commands, MCP config, and hooks.
+
 ### Conversion Config Fields
 
 | Field | Type | Default | Description |

--- a/src/ai_config/converters/emitters.py
+++ b/src/ai_config/converters/emitters.py
@@ -45,6 +45,16 @@ _ENV_VAR_PATTERN = re.compile(
 )
 
 
+def _is_safe_relative_path(path: Path) -> bool:
+    """Return True when path is safe to emit relative to an output root."""
+    return not path.is_absolute() and ".." not in path.parts
+
+
+def _paths_conflict(left: Path, right: Path) -> bool:
+    """Return True when two relative output paths cannot coexist on disk."""
+    return left == right or left in right.parents or right in left.parents
+
+
 @dataclass
 class EmittedFile:
     """A file to be written by the emitter."""
@@ -175,6 +185,113 @@ class EmitResult:
                     full_path.chmod(full_path.stat().st_mode | 0o111)
             written.append(full_path)
         return written
+
+    def apply_target_native_files(
+        self,
+        *,
+        plugin_root: Path | None,
+        target: TargetTool,
+        base_dir: Path,
+    ) -> None:
+        """Copy target-native plugin files into the emitted output.
+
+        Plugins can provide files under ``targets/<target>/`` when a target needs
+        hand-written config that should be copied verbatim instead of generated.
+        Native files are rooted at the target's natural config directory. If a
+        native file conflicts with generated output, the native file wins.
+        """
+        if plugin_root is None:
+            return
+
+        target_root = plugin_root / "targets" / target.value
+        if target_root.is_symlink():
+            self.add_diagnostic(
+                Severity.WARN,
+                f"Ignoring symlinked target-native directory: {target_root}",
+                component_ref=f"file:targets/{target.value}",
+            )
+            return
+        if not target_root.is_dir():
+            return
+
+        for source in sorted(target_root.rglob("*")):
+            if source.is_symlink() or not source.is_file():
+                continue
+
+            relpath = source.relative_to(target_root)
+            if not _is_safe_relative_path(relpath):
+                self.add_diagnostic(
+                    Severity.WARN,
+                    f"Ignoring unsafe target-native file path: {relpath.as_posix()}",
+                    component_ref=f"file:targets/{target.value}/{relpath.as_posix()}",
+                )
+                continue
+
+            target_path = base_dir / relpath
+            if not _is_safe_relative_path(target_path):
+                self.add_diagnostic(
+                    Severity.WARN,
+                    f"Ignoring target-native file outside output root: {target_path.as_posix()}",
+                    component_ref=f"file:targets/{target.value}/{relpath.as_posix()}",
+                )
+                continue
+
+            executable = bool(source.stat().st_mode & 0o111)
+            content_bytes = source.read_bytes()
+
+            conflicts = [
+                (index, emitted)
+                for index, emitted in enumerate(self.files)
+                if _paths_conflict(emitted.path, target_path)
+            ]
+            replaced = bool(conflicts)
+            exact_conflict = next(
+                (index for index, emitted in conflicts if emitted.path == target_path),
+                None,
+            )
+
+            if exact_conflict is not None and len(conflicts) == 1:
+                try:
+                    content = content_bytes.decode("utf-8")
+                    self.files[exact_conflict] = EmittedFile(
+                        path=target_path,
+                        content=content,
+                        executable=executable,
+                    )
+                except UnicodeDecodeError:
+                    self.files[exact_conflict] = EmittedFile(
+                        path=target_path,
+                        content=content_bytes,
+                        binary=True,
+                        executable=executable,
+                    )
+            else:
+                for index, _emitted in reversed(conflicts):
+                    del self.files[index]
+                try:
+                    self.add_file(
+                        target_path,
+                        content_bytes.decode("utf-8"),
+                        executable=executable,
+                    )
+                except UnicodeDecodeError:
+                    self.add_binary_file(target_path, content_bytes, executable=executable)
+
+            if replaced:
+                self.add_diagnostic(
+                    Severity.INFO,
+                    f"Target-native file overrides generated output: {target_path.as_posix()}",
+                    component_ref=f"file:targets/{target.value}/{relpath.as_posix()}",
+                )
+
+            self.add_mapping(
+                "file",
+                f"targets/{target.value}/{relpath.as_posix()}",
+                MappingStatus.NATIVE,
+                target_path=target_path,
+                notes="Target-native file copied verbatim into converted output"
+                + (" and overrides generated output" if replaced else ""),
+            )
 
     def preview(self, output_dir: Path | None = None) -> str:
         """Generate preview of what would be written.
@@ -486,6 +603,12 @@ class CodexEmitter:
                 MappingStatus.UNSUPPORTED,
                 notes="Codex does not support custom LSP servers",
             )
+
+        result.apply_target_native_files(
+            plugin_root=ir.source_path,
+            target=self.target,
+            base_dir=Path(".codex"),
+        )
 
         return result
 
@@ -849,6 +972,12 @@ class CursorEmitter:
                 notes="Cursor handles LSP internally",
             )
 
+        result.apply_target_native_files(
+            plugin_root=ir.source_path,
+            target=self.target,
+            base_dir=Path(".cursor"),
+        )
+
         return result
 
     def _emit_skill(self, result: EmitResult, skill: Skill, plugin_id: str) -> None:
@@ -1069,6 +1198,12 @@ class OpenCodeEmitter:
                 notes="OpenCode does not support custom agent definitions",
             )
 
+        result.apply_target_native_files(
+            plugin_root=ir.source_path,
+            target=self.target,
+            base_dir=Path("."),
+        )
+
         return result
 
     def _emit_skill(self, result: EmitResult, skill: Skill, plugin_id: str) -> None:
@@ -1281,6 +1416,12 @@ class PiEmitter:
                 MappingStatus.UNSUPPORTED,
                 notes="Pi does not support custom LSP servers",
             )
+
+        result.apply_target_native_files(
+            plugin_root=ir.source_path,
+            target=self.target,
+            base_dir=self._base_dir,
+        )
 
         return result
 

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -22,7 +22,7 @@ from ai_config.types import (
     TargetConfig,
 )
 
-_CONVERSION_CACHE_VERSION = 2
+_CONVERSION_CACHE_VERSION = 3
 
 
 def _conversion_cache_path() -> Path:

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -847,6 +847,160 @@ class TestPiEmitter:
         assert asset.exists()
         assert asset.read_bytes() == b"\x01\x02\x03"
 
+    def test_target_native_files_emit_to_project_scope(self, tmp_path: Path) -> None:
+        """Pi target-native files are copied under .pi/ for project scope."""
+        plugin_dir = tmp_path / "native-plugin"
+        native_extension = plugin_dir / "targets" / "pi" / "extensions" / "custom.ts"
+        native_extension.parent.mkdir(parents=True)
+        native_extension.write_text(
+            "export default function (pi: any) { pi.on('input', () => {}); }\n"
+        )
+
+        ir = PluginIR(
+            identity=PluginIdentity(plugin_id="native-plugin", name="native-plugin"),
+            source_path=plugin_dir,
+        )
+        result = PiEmitter(scope=InstallScope.PROJECT).emit(ir)
+        result.write_to(tmp_path)
+
+        extension = tmp_path / ".pi" / "extensions" / "custom.ts"
+        assert extension.exists()
+        assert extension.read_text() == native_extension.read_text()
+
+        file_mappings = [m for m in result.mappings if m.component_kind == "file"]
+        assert file_mappings[0].status == MappingStatus.NATIVE
+        assert file_mappings[0].target_path == Path(".pi") / "extensions" / "custom.ts"
+
+    def test_target_native_files_emit_to_user_scope(self, tmp_path: Path) -> None:
+        """Pi target-native files are copied under .pi/agent/ for user scope."""
+        plugin_dir = tmp_path / "native-plugin"
+        native_extension = plugin_dir / "targets" / "pi" / "extensions" / "custom.ts"
+        native_extension.parent.mkdir(parents=True)
+        native_extension.write_text(
+            "export default function (pi: any) { pi.on('input', () => {}); }\n"
+        )
+
+        ir = PluginIR(
+            identity=PluginIdentity(plugin_id="native-plugin", name="native-plugin"),
+            source_path=plugin_dir,
+        )
+        result = PiEmitter(scope=InstallScope.USER).emit(ir)
+        result.write_to(tmp_path)
+
+        extension = tmp_path / ".pi" / "agent" / "extensions" / "custom.ts"
+        assert extension.exists()
+        assert extension.read_text() == native_extension.read_text()
+        assert not (tmp_path / ".pi" / "extensions").exists()
+
+    def test_target_native_symlink_root_is_ignored(self, tmp_path: Path) -> None:
+        """Symlinked target-native roots are ignored to keep output cache-safe."""
+        plugin_dir = tmp_path / "native-plugin"
+        external_dir = tmp_path / "external-pi-files"
+        external_extension = external_dir / "extensions" / "outside.ts"
+        external_extension.parent.mkdir(parents=True)
+        external_extension.write_text("export default function (pi: any) {}\n")
+
+        targets_dir = plugin_dir / "targets"
+        targets_dir.mkdir(parents=True)
+        (targets_dir / "pi").symlink_to(external_dir, target_is_directory=True)
+
+        ir = PluginIR(
+            identity=PluginIdentity(plugin_id="native-plugin", name="native-plugin"),
+            source_path=plugin_dir,
+        )
+        result = PiEmitter(scope=InstallScope.USER).emit(ir)
+        result.write_to(tmp_path)
+
+        assert not (tmp_path / ".pi" / "agent" / "extensions" / "outside.ts").exists()
+        assert any(
+            "Ignoring symlinked target-native directory" in diagnostic.message
+            for diagnostic in result.diagnostics
+        )
+
+    def test_target_native_file_overrides_generated_directory(self, tmp_path: Path) -> None:
+        """Target-native files cleanly replace generated output directories."""
+        plugin_dir = tmp_path / "native-plugin"
+        native_skill_path = plugin_dir / "targets" / "pi" / "skills" / "native-plugin-review"
+        native_skill_path.parent.mkdir(parents=True)
+        native_skill_path.write_text("native file replacing generated skill directory\n")
+
+        ir = PluginIR(
+            identity=PluginIdentity(plugin_id="native-plugin", name="native-plugin"),
+            components=[
+                Skill(
+                    name="review",
+                    description="Generated skill that will be overridden",
+                    files=[
+                        TextFile(
+                            relpath="SKILL.md",
+                            content="---\nname: review\ndescription: test\n---\nBody",
+                        ),
+                    ],
+                )
+            ],
+            source_path=plugin_dir,
+        )
+        result = PiEmitter(scope=InstallScope.PROJECT).emit(ir)
+        result.write_to(tmp_path)
+
+        output_path = tmp_path / ".pi" / "skills" / "native-plugin-review"
+        assert output_path.is_file()
+        assert output_path.read_text() == native_skill_path.read_text()
+        assert not (output_path / "SKILL.md").exists()
+        assert any(
+            "overrides generated output" in (mapping.notes or "")
+            for mapping in result.mappings
+            if mapping.component_kind == "file"
+        )
+
+    def test_target_native_files_override_generated_output(self, tmp_path: Path) -> None:
+        """Target-native files win when they collide with generated Pi output."""
+        plugin_dir = tmp_path / "native-plugin"
+        (plugin_dir / ".claude-plugin").mkdir(parents=True)
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "native-plugin", "hooks": "./hooks/hooks.json"})
+        )
+        hooks_dir = plugin_dir / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "hooks.json").write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check.sh",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+        native_extension = plugin_dir / "targets" / "pi" / "extensions" / "native-plugin-hooks.ts"
+        native_extension.parent.mkdir(parents=True)
+        native_extension.write_text("// native override\nexport default function (pi: any) {}\n")
+
+        ir = parse_claude_plugin(plugin_dir)
+        result = PiEmitter(scope=InstallScope.USER).emit(ir)
+        result.write_to(tmp_path)
+
+        extension = tmp_path / ".pi" / "agent" / "extensions" / "native-plugin-hooks.ts"
+        assert extension.read_text() == native_extension.read_text()
+        assert "runHook" not in extension.read_text()
+        assert any(
+            "overrides generated output" in (mapping.notes or "")
+            for mapping in result.mappings
+            if mapping.component_kind == "file"
+        )
+        assert any(
+            "overrides generated output" in diagnostic.message for diagnostic in result.diagnostics
+        )
+
 
 class TestEmitterFactory:
     """Tests for emitter factory."""


### PR DESCRIPTION
## Summary
- add `targets/<target>/...` target-native conversion files that are emitted into the target output after generated files
- make native files win over generated path collisions, with conversion mappings/diagnostics
- harden target-native copy behavior by rejecting symlinked target roots and bumping the conversion cache version
- document the convention for target-specific glue like custom Pi extensions

## Test plan
- [x] `uv run pytest tests/unit/converters/test_conversion.py tests/unit/test_operations.py tests/unit/test_cli_doctor_target.py -q`
- [x] `uv run ruff check src/ tests/ && uv run ty check src/`
- [x] `uv run pytest tests/unit -q`
- [x] `uv run mkdocs build --strict`
- [x] `uv tool install --reinstall . && cd ~/git_repositories/dots && DOTS_REPO=$PWD ai-config sync -c config/ai-config/config.yaml --force --fresh --verify && cmp config/ai-config/plugins/alex-ai/targets/pi/extensions/alex-ai-hooks.ts ~/.pi/agent/extensions/alex-ai-hooks.ts`

## Notes
- Dogfooded against the paired dots change that moves `alex-ai-hooks.ts` under `config/ai-config/plugins/alex-ai/targets/pi/extensions/`.
- HK evidence recorded under work item `2026-05-28-141832-target-native-overrides`.

🤖 Generated with [Pi](https://github.com/earendil-works/pi-coding-agent)
