### PR TITLE
Spike Codex plugin package target feasibility

### DIFF
--- a/ai_agent_docs/conversion-pipeline.md
+++ b/ai_agent_docs/conversion-pipeline.md
@@ -42,6 +42,11 @@ Duck-typed classes sharing the same shape (no explicit Protocol ABC):
 
 Factory: `get_emitter(target, scope, commands_as_skills) -> Emitter`
 
+The Codex emitter owns loose files, not installable plugin packages. It writes namespaced skills,
+deprecated prompts or command-as-skill output, MCP TOML, and hook JSON. `EmitResult.write_to()`
+merges existing Codex `config.toml` and `hooks.json` data instead of replacing shared user state.
+Target-native Codex files pass through the same loose output root and merge rules.
+
 Each emitter returns `EmitResult` containing:
 - `EmittedFile` list (path + content + binary flag)
 - `ComponentMapping` list (fidelity tracking per component)
@@ -70,6 +75,32 @@ preview_conversion(plugin_path, targets) -> str
 - `UNSUPPORTED` → skipped
 
 Output: `.summary()`, `.to_json()`, `.to_markdown()`
+
+Each requested target owns its own `EmitResult`, `ConversionReport`, mappings, and output paths.
+Degraded Codex mappings do not change Cursor, OpenCode, or Pi mappings. An unexpected emitter
+exception still aborts the multi-target conversion unless best-effort mode is enabled. This
+per-target ownership boundary is also why an installable package must not silently replace the
+existing Codex mode.
+
+## Experimental Codex package boundary
+
+Issue #13 proved a public Codex plugin manifest and marketplace lifecycle with the fixture under
+`tests/fixtures/experimental/codex-plugin-marketplace/`. The fixture and
+`tests/probes/probe_codex_plugin_package.py` do not add a `TargetTool`, emitter factory branch,
+validator registration, config literal, sync path, or CLI choice.
+
+The current IR can carry the package's tested skill and hook. It also carries MCP server definitions,
+which the public package contract accepts through `mcpServers`. It does not model all marketplace
+listing fields or published-plugin interface metadata. Commands need an explicit package mapping
+because the public bundle contract documents skills rather than loose custom prompts. Agents and LSP
+servers remain unsupported for Codex.
+
+A package emitter would write an owned plugin directory and marketplace entry, not merge into shared
+`config.toml` or `hooks.json`. A separate package validator would check manifest and marketplace
+references; `CodexOutputValidator` must continue to check loose `.codex/` output. Existing mapping
+statuses and reports can represent package files without a cross-tool package abstraction. See the
+[compatibility baseline](target-compatibility-baseline.md#pluginpackage-contract) for the evidence,
+single decision, and follow-up slices.
 
 ## Adding a New Target
 

--- a/ai_agent_docs/target-compatibility-baseline.md
+++ b/ai_agent_docs/target-compatibility-baseline.md
@@ -2,26 +2,28 @@
 
 This file records the target-runtime assumptions that ai-config's converter support matrix is based on. Update it when target CLI behavior changes or when refreshing conversion support.
 
-Last checked: 2026-05-15
-Context: Codex/Pi skill discovery collision refresh
+Last checked: 2026-07-13
+Context: Codex plugin/package feasibility spike ([issue #13](https://github.com/safurrier/ai-config/issues/13))
 
-Observed local versions during the Codex/Pi release-note delta pass:
+Current Codex snapshot:
 
 ```text
-codex --version  -> codex-cli 0.128.0
-pi --version     -> 0.74.0
-npm latest Codex -> @openai/codex 0.129.0
-npm latest Pi    -> @earendil-works/pi-coding-agent 0.74.0
+command: /opt/homebrew/bin/codex --version
+output:  codex-cli 0.142.3
+binary:  /opt/homebrew/bin/codex
+root:    /opt/homebrew/Caskroom/codex/0.142.3/
+host:    local macOS Homebrew cask installation
 ```
 
-Codex plugin/package distribution is tracked as a follow-up in [issue #13](https://github.com/safurrier/ai-config/issues/13); it is not a blocker for the current loose-file Codex target.
+The earlier multi-tool snapshot remains `pi 0.74.0`, npm Codex `0.129.0`, and npm Pi
+`0.74.0` as of 2026-05-15; those tools were not refreshed for this Codex-only spike.
 
 ## Summary
 
 | Target | Observed support | ai-config output | Runtime validation |
 |---|---|---|---|
 | Claude Code | Native plugin marketplace, skills, hooks, MCP | Source tool, not emitted by converter | `claude plugin validate`, `claude plugin list --json`, `claude mcp list` |
-| Codex | Agent Skills, MCP in `config.toml`, hooks behind `codex_hooks` | `.codex/skills/`, `.codex/config.toml`, `.codex/hooks.json`, prompts | `codex debug prompt-input`, `CODEX_HOME=<generated> codex mcp list` |
+| Codex | Agent Skills, MCP in `config.toml`, hooks, and installable plugin bundles | Loose files under `.codex/`; experimental package fixture is test-only | `codex debug prompt-input`, `codex mcp list`, and the isolated plugin package probe |
 | Cursor | Skills, MCP JSON, hooks JSON | `.cursor/skills/`, `.cursor/mcp.json`, `.cursor/hooks.json` | JSON validation, `cursor-agent mcp list` when available |
 | OpenCode | Skills, MCP/config, LSP/config debug surfaces | `.opencode/skills/`, `opencode.json`, `opencode.lsp.json` | `opencode debug skill`, `opencode debug config`, `opencode mcp list` |
 | Pi | Skills, prompt templates, TypeScript extensions | `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/`; user-scope under `.pi/agent/` | RPC `get_commands`, `pi --extension` marker hook |
@@ -57,20 +59,147 @@ claude mcp list 2>&1
 
 ### Codex
 
-- Agent Skills are discovered from `.codex/skills` for project output and `$HOME/.codex/skills` for user output.
-- Avoid emitting Codex skills into `.agents/skills`: Pi also scans that generic Agent Skills directory, so Codex-only output there creates duplicate Pi skill listings and validation warnings.
-- MCP servers are configured in `.codex/config.toml` under `[mcp_servers.*]`.
-- Supported command hooks can be emitted to `.codex/hooks.json` with `[features].codex_hooks = true`.
-- Shared Codex files must be merged, not clobbered.
-- TOML keys that are not valid bare keys must remain quoted, e.g. `[mcp_servers."github.com"]`.
-- Codex release notes now emphasize plugin workflows, plugin-bundled hooks, marketplace install/share/cache, and external-agent config import. ai-config's current `codex` target intentionally remains a loose-file target; a first-class Codex plugin/package target is deferred to [issue #13](https://github.com/safurrier/ai-config/issues/13).
+#### Existing loose-file target
 
-Validation patterns:
+The production `codex` target is unchanged by the package spike:
+
+- Agent Skills go to `.codex/skills` for project and user output. They do not go to
+  `.agents/skills`, which Pi also scans and would report as duplicate output.
+- Commands become deprecated custom prompts by default or skills with
+  `--commands-as-skills`. MCP servers become `[mcp_servers.*]` tables in
+  `.codex/config.toml`. Supported command hooks become `.codex/hooks.json`.
+- Shared `config.toml` and `hooks.json` files are merged on write. Unrelated existing settings,
+  hooks, and quoted keys are preserved; generated values replace conflicting keys, and generated
+  hooks are deduplicated.
+- `CodexOutputValidator` checks loose skill frontmatter, TOML structure and MCP entries,
+  hook JSON, and deprecated prompts. It does not validate plugin manifests or marketplaces.
+- Conversion reports use the common mapping statuses. Skills are native, MCP and supported hooks
+  are transforms, prompts are a degraded fallback, and agents/LSP servers are skipped. Target
+  mappings and output ownership remain separate. An unexpected emitter exception still aborts a
+  multi-target conversion unless `--best-effort` is enabled.
+
+The loose target's hook flag is now stale: Codex 0.142.3 lists `hooks` as stable and the hooks
+page calls `codex_hooks` a deprecated alias. This spike does not change that production behavior.
+
+Loose-file validation remains:
 
 ```bash
 codex -C <generated-project> debug prompt-input "test" | grep <generated-skill>
 CODEX_HOME=<generated>/.codex codex mcp list
 ```
+
+#### Plugin/package contract
+
+Official sources checked on 2026-07-13:
+
+- [Codex changelog](https://developers.openai.com/codex/changelog) — the 2026-03-25 entry
+  announces plugins across the app, CLI, and IDE extensions, packaging skills, app integrations,
+  and MCP server configuration. The same changelog listed newer CLI releases than the locally
+  tested 0.142.3, so all runtime observations below are version-scoped.
+- [Plugins](https://learn.chatgpt.com/docs/plugins) — install/use/remove behavior and bundled
+  skills, connectors, MCP servers, and hooks.
+- [Build plugins](https://learn.chatgpt.com/docs/build-plugins) — required
+  `.codex-plugin/plugin.json`, marketplace schema and locations, local/Git/npm sources, cache,
+  config toggles, skills, hooks, apps, and MCP package fields.
+- [Build skills](https://learn.chatgpt.com/docs/build-skills) — skill layout, discovery, and
+  `[[skills.config]]` enable/disable entries.
+- [Hooks](https://learn.chatgpt.com/docs/hooks) — hook files, stable `hooks` flag, plugin hook
+  trust, events, and `PLUGIN_ROOT`/`PLUGIN_DATA`.
+- [Developer commands](https://learn.chatgpt.com/docs/developer-commands?surface=cli) — CLI global
+  flags, including `--strict-config`, `--enable`, and `--disable`.
+- [Submit plugins](https://learn.chatgpt.com/docs/submit-plugins) — public submission supports
+  skills-only, MCP-backed app, and combined packages; publication validation is portal-based.
+- [Codex `plugin-json-spec.md`](https://github.com/openai/codex/blob/bbe93d3e5f22202362cac87e7e9dc755d8706a8a/codex-rs/skills/src/assets/samples/plugin-creator/references/plugin-json-spec.md)
+  at repository commit `bbe93d3e5f22202362cac87e7e9dc755d8706a8a` — built-in creator reference
+  for manifest and marketplace fields. Its validator note rejects `hooks`, while current public
+  build and hooks pages accept that field; the current pages and successful CLI ingestion are the
+  evidence used for this fixture.
+
+Evidence classification:
+
+| Class | Evidence and implication |
+|---|---|
+| Documented stable | `plugins`, `plugin_sharing`, and `hooks` report stage `stable` and effective `true`. Public docs define the plugin manifest, marketplace, local/Git/npm sources, cache path, plugin toggle, skills, hooks, MCP servers, apps, install, and removal. |
+| Experimental | The fixture and probe in this repository are explicitly experimental. Upstream `remote_plugin` reports `under development` and `false`; it is outside the proposed local/Git/npm generation contract. |
+| Undocumented/version-specific | The public build page documents marketplace CLI commands but not the full `plugin add/list/remove` JSON contract. Their 0.142.3 `--help` and observed JSON are version-specific evidence. No `codex plugin validate` command exists, and `--strict-config` is rejected for `codex plugin`. |
+| Inferred | A successful `plugin add` proves that this fixture is accepted and copied, not that every public manifest rule was checked. Cache deletion on `plugin remove` and skill absence while the plugin is disabled were observed in the isolated probe. |
+
+Exact help and feature capture commands:
+
+```bash
+/opt/homebrew/bin/codex --version
+/opt/homebrew/bin/codex --help
+/opt/homebrew/bin/codex plugin --help
+/opt/homebrew/bin/codex plugin add --help
+/opt/homebrew/bin/codex plugin list --help
+/opt/homebrew/bin/codex plugin remove --help
+/opt/homebrew/bin/codex plugin marketplace --help
+/opt/homebrew/bin/codex plugin marketplace add --help
+/opt/homebrew/bin/codex plugin marketplace list --help
+/opt/homebrew/bin/codex plugin marketplace upgrade --help
+/opt/homebrew/bin/codex plugin marketplace remove --help
+/opt/homebrew/bin/codex doctor --help
+/opt/homebrew/bin/codex debug --help
+/opt/homebrew/bin/codex features list
+```
+
+The auth-free lifecycle probe uses fresh temporary values for both `HOME` and `CODEX_HOME`, removes
+known API credential variables from its child environment, and runs:
+
+```bash
+uv run python tests/probes/probe_codex_plugin_package.py
+
+codex plugin marketplace list --json
+codex plugin marketplace add <fixture-root> --json
+codex plugin list --available --json
+codex plugin add experimental-package@ai-config-experimental --json
+codex plugin list --json
+codex -C <fixture-root> debug prompt-input probe
+# edit only temporary config: [plugins."experimental-package@ai-config-experimental"] enabled=false
+codex plugin list --json
+codex -C <fixture-root> debug prompt-input probe
+# restore enabled=true in the same temporary config
+codex --strict-config plugin list --json
+codex --strict-config doctor --json
+codex plugin remove experimental-package@ai-config-experimental --json
+codex plugin marketplace remove ai-config-experimental --json
+```
+
+Observed behavior on 0.142.3:
+
+- Marketplace add/list and plugin available/add/list/remove succeeded without authentication.
+- Install copied the manifest, one skill, and one hook file to
+  `$CODEX_HOME/plugins/cache/ai-config-experimental/experimental-package/0.1.0/` and wrote an
+  enabled plugin table to temporary `config.toml`.
+- `debug prompt-input` found `experimental-package:hello` when enabled, omitted it when disabled,
+  and found it again after re-enabling. The probe does not trust or execute the bundled hook.
+- Remove deleted the cached version and plugin config; marketplace remove deleted its config.
+- `codex --strict-config doctor --json` reported `config.load` as `ok` even though the overall
+  auth-free doctor result can fail its separate credential check. Strict config cannot be applied
+  directly to plugin subcommands. There is no public auth-free standalone plugin validator.
+- Public package fields cover skills, hooks, MCP servers, apps/connectors, and npm-backed package
+  sources. The minimal fixture uses one skill and one hook. MCP/app/npm behavior is documented but
+  not exercised because the bounded proof needs no server, credentials, network package, or app ID.
+
+**Recommendation (issue option 2): add a future opt-in `codex-plugin` target.** Keep `codex` as the
+loose-file default. A separate target matches the package's install/cache lifecycle and avoids
+mixing immutable bundle output with the existing shared-config merge contract.
+
+Implementation-ready follow-up:
+
+1. Add a package emitter behind a new opt-in target only when implementation work is authorized.
+   Reuse `PluginIR` for identity, skills, hooks, and MCP servers; emit commands as package skills or
+   diagnose them, and keep agents/LSP unsupported. Add only metadata fields required by a chosen
+   publishing tier rather than copying the whole public listing schema into IR.
+2. Emit one self-contained plugin root plus an optional repo marketplace entry. Do not merge package
+   content into `.codex/config.toml`; installed enable state and plugin-scoped MCP policy remain
+   Codex-owned user state.
+3. Add a package validator for manifest paths, names, semver, skill files, hook JSON, MCP JSON, and
+   marketplace references. Keep it separate from `CodexOutputValidator`. Report package files and
+   mappings through the existing `ConversionReport` model.
+4. Register the target across CLI/config/sync only after unit coverage and this isolated probe pass.
+   Add Docker coverage pinned to a known Codex version. Preserve independent per-target reports and
+   verify that selecting `codex-plugin` never changes loose `codex`, Cursor, OpenCode, or Pi output.
 
 ### Pi
 

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -15,6 +15,14 @@ The `convert` command takes a Claude Code plugin directory and produces equivale
 
 Each target gets the closest equivalent of your plugin's skills, commands, hooks, MCP servers, and LSP servers — with diagnostics when something can't convert cleanly.
 
+### Codex output is loose-file output
+
+The production `codex` target writes skills and shared Codex config files. It does not create an
+installable `.codex-plugin/plugin.json` package or marketplace entry. The experimental package
+fixture used for the [current compatibility baseline](https://github.com/safurrier/ai-config/blob/main/ai_agent_docs/target-compatibility-baseline.md#pluginpackage-contract)
+is test-only and is not registered as a conversion target. Selecting `codex` keeps the existing
+loose-file behavior.
+
 ## Quick Start
 
 Convert a plugin to all targets:

--- a/tests/fixtures/experimental/codex-plugin-marketplace/.agents/plugins/marketplace.json
+++ b/tests/fixtures/experimental/codex-plugin-marketplace/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "ai-config-experimental",
+  "interface": {
+    "displayName": "ai-config experimental"
+  },
+  "plugins": [
+    {
+      "name": "experimental-package",
+      "source": {
+        "source": "local",
+        "path": "./plugins/experimental-package"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/tests/fixtures/experimental/codex-plugin-marketplace/plugins/experimental-package/.codex-plugin/plugin.json
+++ b/tests/fixtures/experimental/codex-plugin-marketplace/plugins/experimental-package/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "experimental-package",
+  "version": "0.1.0",
+  "description": "Experimental local package for an auth-free Codex CLI probe.",
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
+}

--- a/tests/fixtures/experimental/codex-plugin-marketplace/plugins/experimental-package/hooks/hooks.json
+++ b/tests/fixtures/experimental/codex-plugin-marketplace/plugins/experimental-package/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf plugin-probe"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/experimental/codex-plugin-marketplace/plugins/experimental-package/skills/hello/SKILL.md
+++ b/tests/fixtures/experimental/codex-plugin-marketplace/plugins/experimental-package/skills/hello/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: hello
+description: Return a deterministic greeting for plugin package probing.
+---
+
+Return exactly: hello from the experimental Codex plugin package.

--- a/tests/probes/probe_codex_plugin_package.py
+++ b/tests/probes/probe_codex_plugin_package.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Probe the experimental Codex plugin fixture without using live config or credentials."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import cast
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+PLUGIN_ID = "experimental-package@ai-config-experimental"
+MARKETPLACE_NAME = "ai-config-experimental"
+SKILL_MARKER = "experimental-package:hello"
+SENSITIVE_ENV_VARS = {
+    "CHATGPT_API_KEY",
+    "CODEX_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_ORG_ID",
+    "OPENAI_PROJECT_ID",
+}
+
+
+def run_codex(
+    codex: str,
+    args: list[str],
+    env: dict[str, str],
+    *,
+    expected_codes: tuple[int, ...] = (0,),
+) -> subprocess.CompletedProcess[str]:
+    """Run one isolated Codex command and fail with its captured output."""
+    result = subprocess.run(
+        [codex, *args],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    if result.returncode not in expected_codes:
+        command = " ".join([codex, *args])
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {command}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def load_json(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    """Parse a JSON object from a successful Codex command."""
+    payload: object = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise AssertionError("expected a JSON object from Codex")
+    return cast(dict[str, object], payload)
+
+
+def object_field_equals(value: object, key: str, expected: object) -> bool:
+    """Return whether a JSON object contains the expected field value."""
+    if not isinstance(value, dict):
+        return False
+    return cast(dict[str, object], value).get(key) == expected
+
+
+def installed_plugin(payload: dict[str, object]) -> dict[str, object]:
+    """Return the probe plugin entry from a plugin-list response."""
+    installed = payload.get("installed")
+    if not isinstance(installed, list):
+        raise AssertionError("plugin list did not contain an installed array")
+    for entry in installed:
+        if object_field_equals(entry, "pluginId", PLUGIN_ID):
+            return cast(dict[str, object], entry)
+    raise AssertionError(f"{PLUGIN_ID} was not listed as installed")
+
+
+def set_plugin_enabled(config_path: Path, enabled: bool) -> None:
+    """Toggle only the probe plugin in the temporary Codex config."""
+    old = f'[plugins."{PLUGIN_ID}"]\nenabled = {str(not enabled).lower()}'
+    new = f'[plugins."{PLUGIN_ID}"]\nenabled = {str(enabled).lower()}'
+    config = config_path.read_text(encoding="utf-8")
+    if config.count(old) != 1:
+        raise AssertionError("temporary config did not contain the expected plugin toggle")
+    config_path.write_text(config.replace(old, new), encoding="utf-8")
+
+
+def probe(codex: str, fixture_root: Path) -> dict[str, str]:
+    """Exercise marketplace and plugin lifecycle in disposable HOME directories."""
+    if not (fixture_root / ".agents/plugins/marketplace.json").is_file():
+        raise FileNotFoundError(f"invalid marketplace fixture: {fixture_root}")
+
+    with tempfile.TemporaryDirectory(prefix="ai-config-codex-plugin-") as tmp:
+        temp_root = Path(tmp)
+        home = temp_root / "home"
+        codex_home = home / ".codex"
+        codex_home.mkdir(parents=True)
+
+        env = {key: value for key, value in os.environ.items() if key not in SENSITIVE_ENV_VARS}
+        env.update({"HOME": str(home), "CODEX_HOME": str(codex_home)})
+
+        version = run_codex(codex, ["--version"], env).stdout.strip()
+        features = run_codex(codex, ["features", "list"], env).stdout
+        for expected in (
+            "hooks                                stable             true",
+            "plugin_sharing                       stable             true",
+            "plugins                              stable             true",
+            "remote_plugin                        under development  false",
+        ):
+            if expected not in features:
+                raise AssertionError(f"missing expected feature row: {expected}")
+
+        plugin_help = run_codex(codex, ["plugin", "--help"], env).stdout
+        if "validate" in plugin_help:
+            raise AssertionError("update the probe: Codex now exposes plugin validation")
+
+        initial_marketplaces = load_json(
+            run_codex(codex, ["plugin", "marketplace", "list", "--json"], env)
+        )
+        if initial_marketplaces != {"marketplaces": []}:
+            raise AssertionError("temporary Codex home was not empty")
+
+        added = load_json(
+            run_codex(
+                codex,
+                ["plugin", "marketplace", "add", str(fixture_root), "--json"],
+                env,
+            )
+        )
+        if added.get("marketplaceName") != MARKETPLACE_NAME:
+            raise AssertionError("Codex added an unexpected marketplace")
+
+        marketplaces = load_json(run_codex(codex, ["plugin", "marketplace", "list", "--json"], env))
+        listed_marketplaces = marketplaces.get("marketplaces")
+        if not isinstance(listed_marketplaces, list) or not any(
+            object_field_equals(entry, "name", MARKETPLACE_NAME) for entry in listed_marketplaces
+        ):
+            raise AssertionError("added marketplace was not listed")
+
+        available = load_json(
+            run_codex(codex, ["plugin", "list", "--available", "--json"], env)
+        ).get("available")
+        if not isinstance(available, list) or not any(
+            object_field_equals(entry, "pluginId", PLUGIN_ID) for entry in available
+        ):
+            raise AssertionError("fixture plugin was not available")
+
+        install = load_json(run_codex(codex, ["plugin", "add", PLUGIN_ID, "--json"], env))
+        install_path_value = install.get("installedPath")
+        if not isinstance(install_path_value, str):
+            raise AssertionError("install result omitted installedPath")
+        install_path = Path(install_path_value)
+        expected_files = (
+            ".codex-plugin/plugin.json",
+            "skills/hello/SKILL.md",
+            "hooks/hooks.json",
+        )
+        for relative_path in expected_files:
+            if not (install_path / relative_path).is_file():
+                raise AssertionError(f"installed cache omitted {relative_path}")
+
+        config_path = codex_home / "config.toml"
+        with config_path.open("rb") as config_file:
+            config = tomllib.load(config_file)
+        plugins_config = config.get("plugins")
+        if not isinstance(plugins_config, dict):
+            raise AssertionError("install did not create a plugins config table")
+        plugin_config = plugins_config.get(PLUGIN_ID)
+        if not isinstance(plugin_config, dict) or plugin_config.get("enabled") is not True:
+            raise AssertionError("install did not enable the plugin in config.toml")
+
+        listed = load_json(run_codex(codex, ["plugin", "list", "--json"], env))
+        if installed_plugin(listed).get("enabled") is not True:
+            raise AssertionError("installed plugin was not enabled")
+
+        prompt = run_codex(
+            codex,
+            ["-C", str(fixture_root), "debug", "prompt-input", "probe"],
+            env,
+        ).stdout
+        if SKILL_MARKER not in prompt:
+            raise AssertionError("enabled plugin skill was not discovered")
+
+        set_plugin_enabled(config_path, False)
+        disabled = load_json(run_codex(codex, ["plugin", "list", "--json"], env))
+        if installed_plugin(disabled).get("enabled") is not False:
+            raise AssertionError("disabled plugin was still reported as enabled")
+        disabled_prompt = run_codex(
+            codex,
+            ["-C", str(fixture_root), "debug", "prompt-input", "probe"],
+            env,
+        ).stdout
+        if SKILL_MARKER in disabled_prompt:
+            raise AssertionError("disabled plugin skill was still discovered")
+
+        set_plugin_enabled(config_path, True)
+        enabled_prompt = run_codex(
+            codex,
+            ["-C", str(fixture_root), "debug", "prompt-input", "probe"],
+            env,
+        ).stdout
+        if SKILL_MARKER not in enabled_prompt:
+            raise AssertionError("re-enabled plugin skill was not discovered")
+
+        strict_plugin = run_codex(
+            codex,
+            ["--strict-config", "plugin", "list", "--json"],
+            env,
+            expected_codes=(1,),
+        )
+        if "not supported for `codex plugin`" not in strict_plugin.stderr:
+            raise AssertionError("strict-config behavior for plugin commands changed")
+
+        doctor = load_json(
+            run_codex(
+                codex,
+                ["--strict-config", "doctor", "--json"],
+                env,
+                expected_codes=(0, 1),
+            )
+        )
+        checks = doctor.get("checks")
+        checks_by_name = cast(dict[str, object], checks) if isinstance(checks, dict) else {}
+        config_check = checks_by_name.get("config.load")
+        if not object_field_equals(config_check, "status", "ok"):
+            raise AssertionError("strict Codex doctor did not load the generated config")
+
+        run_codex(codex, ["plugin", "remove", PLUGIN_ID, "--json"], env)
+        after_remove = load_json(run_codex(codex, ["plugin", "list", "--json"], env))
+        if after_remove.get("installed") != [] or install_path.exists():
+            raise AssertionError("plugin removal left the installed plugin or cache version")
+
+        run_codex(
+            codex,
+            ["plugin", "marketplace", "remove", MARKETPLACE_NAME, "--json"],
+            env,
+        )
+        final_marketplaces = load_json(
+            run_codex(codex, ["plugin", "marketplace", "list", "--json"], env)
+        )
+        if final_marketplaces != {"marketplaces": []}:
+            raise AssertionError("marketplace removal left configured state")
+
+    return {
+        "codex": codex,
+        "version": version,
+        "fixture": str(fixture_root),
+        "result": "passed",
+    }
+
+
+def main() -> None:
+    """Run the probe and print a small machine-readable result."""
+    fixture_root = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "experimental"
+        / "codex-plugin-marketplace"
+    )
+    codex = shutil.which("codex")
+    if codex is None:
+        raise SystemExit("codex executable not found")
+    result = probe(codex, fixture_root)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- record the current public Codex plugin/package contract, release-note evidence, CLI 0.142.3 behavior, and remaining version-specific gaps
- add an explicitly experimental plugin marketplace fixture and auth-free lifecycle probe isolated with temporary `HOME` and `CODEX_HOME`
- keep the production loose-file `codex` target unchanged and recommend a future opt-in `codex-plugin` target with separate emitter and validator ownership

## Decision
Recommend issue option 2: add a future opt-in `codex-plugin` target. Do not replace or add package mode to the existing loose-file target.

## Test plan
- [x] `uv run python tests/probes/probe_codex_plugin_package.py`
- [x] focused Codex emitter, validator, protocol, and doctor tests (29 passed)
- [x] `uv run pytest tests/unit -q` (599 passed)
- [x] Ruff, Ruff format, and ty for the touched probe and production source
- [x] `uv run mkdocs build --strict`
- [x] fresh-context review; three P2 documentation findings fixed and targeted follow-up clean

Fixes #13
