### PR TITLE
Fix source-less Codex metadata and release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-24
+
+### Fixed
+
+- Codex sync now accepts marketplace and plugin catalog rows that omit optional `marketplaceSource` metadata while continuing to reject malformed metadata and fail closed on ownership collisions.
+- Codex plugin lifecycle validation now supports the observed 0.145.x response contract, with pinned and latest-runtime probes covering the release.
+
 ## [0.6.0] - 2026-07-17
 
 ### Added
@@ -151,7 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for GitHub and local marketplaces
 - User and project scope plugin installation
 
-[Unreleased]: https://github.com/safurrier/ai-config/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/safurrier/ai-config/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/safurrier/ai-config/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/safurrier/ai-config/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/safurrier/ai-config/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/safurrier/ai-config/compare/v0.4.1...v0.4.2

--- a/ai_agent_docs/target-compatibility-baseline.md
+++ b/ai_agent_docs/target-compatibility-baseline.md
@@ -2,8 +2,8 @@
 
 This file records the runtime assumptions behind ai-config target conversion.
 
-Last checked: 2026-07-16
-Context: first-class Codex plugin packages for issue #18 / ai-config 0.6.0.
+Last checked: 2026-07-24
+Context: first-class Codex plugin packages for issue #18 / ai-config 0.6.0 and source-less Codex marketplace metadata for issue #20.
 
 ## Summary
 
@@ -15,7 +15,7 @@ Context: first-class Codex plugin packages for issue #18 / ai-config 0.6.0.
 | OpenCode | `.opencode/skills/`, `opencode.json`, `opencode.lsp.json` | `opencode debug skill/config`, `opencode mcp list` |
 | Pi | project `.pi/` or user `.pi/agent/` skills, prompts, extensions | RPC `get_commands` and extension marker probe |
 
-## Codex 0.144.5 evidence
+## Codex 0.144.5 and 0.145.0 evidence
 
 The latest lane resolved npm's `@openai/codex@latest` tag at execution time on 2026-07-16:
 
@@ -27,6 +27,17 @@ main tarball:      https://registry.npmjs.org/@openai/codex/-/codex-0.144.5.tgz
 main integrity:    sha512-jjB+K+OMv572mKhS+2QuLxWXDJNdpwbPenf+V+8bdq7wg4Scqt3cn6WEekD8wPqDVZqck0HSX17K9rD9kbDJQA==
 darwin-arm64:      https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-arm64.tgz
 platform integrity: sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw==
+install source:    integrity-verified direct npm registry tarball extraction
+```
+
+The same lane resolved and passed the complete package and public-sync probes for Codex 0.145.0 on
+2026-07-24:
+
+```text
+resolved package: @openai/codex@0.145.0
+version output:   codex-cli 0.145.0
+main integrity:   sha512-/PSPSFujjjmiyVFvG2yu/grOFhsWdokTH8t2KGWhXSo/M5n/dIDsnbsnO82/7bLtIoDuzQf7ATBUMWqPWQINlQ==
+darwin-arm64 integrity: sha512-h6aQ0UxnaP8mIM/9/qPAH9MNkRliJo88toq1T36IxNM2L5JSU0TFamu+MZn7YkFgDsrp0RfiI+97Tm8AVVxqtA==
 install source:    integrity-verified direct npm registry tarball extraction
 ```
 
@@ -62,9 +73,10 @@ Observed help surfaces:
 | `codex plugin marketplace upgrade --help` | Refresh configured Git marketplace snapshots. |
 | `codex plugin marketplace remove --help` | Remove a configured marketplace source by name |
 
-Official sources checked on 2026-07-16:
+Official sources checked on 2026-07-24:
 
 - [Codex changelog](https://developers.openai.com/codex/changelog)
+- [Codex 0.145.0 release](https://github.com/openai/codex/releases/tag/rust-v0.145.0)
 - [Plugins](https://learn.chatgpt.com/docs/plugins)
 - [Build plugins](https://learn.chatgpt.com/docs/build-plugins)
 - [Build skills](https://learn.chatgpt.com/docs/build-skills)
@@ -94,14 +106,20 @@ duplicate runtime records, source/path mismatches, and SemVer downgrades fail be
 Removal is limited to entries recorded in the ownership file. Possible old loose output is reported
 by `doctor` and never removed without proof of ownership.
 
-The adapter intentionally accepts only the observed Codex 0.144.x contract. It validates the CLI
-version plus typed schemas and semantic identity for marketplace list/add/remove and plugin
+The adapter intentionally accepts only the observed Codex 0.144.x and 0.145.x contracts. It validates
+the CLI version plus typed schemas and semantic identity for marketplace list/add/remove and plugin
 list/add/remove responses. Malformed JSON, duplicate keys/records, partial output, unknown versions,
 and inconsistent success responses are errors. Every call uses a finite timeout and bounds/strips
 control characters from error output. POSIX calls start a separate process group; after a bounded
 SIGTERM grace period, timeout cleanup inspects and kills any remaining group even if the direct child
 already exited, then performs a bounded direct-child reap. Non-POSIX cleanup is limited to the direct
 child; 0.6.0 does not advertise descendant cleanup on those platforms.
+
+Codex 0.144.5 can omit `marketplaceSource` from resolved marketplace and plugin catalog rows when no
+configured source corresponds to the resolved marketplace root. The adapter accepts only absence:
+a present value must remain a typed object with a known source type and non-empty source. Installed
+rows without this metadata retain their plugin source but have no inferred marketplace root, so
+desired or previously owned identity collisions still fail before mutation.
 
 ## Isolated runtime probe
 
@@ -129,10 +147,10 @@ The public-command probe invokes `python -m ai_config sync --config <isolated> -
 disposable source marketplace and real Codex binary. It proves first registration/install,
 unchanged no-op, automatic repair of tampered generated output, SemVer refresh/update and
 discovery, status drift reporting, disabled-plugin reinstall, missing-plugin repair, owned removal,
-and preservation of unrelated marketplace, plugin enablement, and scalar config. The pinned
-all-tools E2E lane runs both probes.
+and preservation of unrelated marketplace, plugin enablement, scalar config, and source-less
+marketplace/plugin catalog state. The pinned all-tools E2E lane runs both probes.
 
-The Docker all-tools image pins `@openai/codex@0.144.5`. The separate workflow latest lane resolves
+The Docker all-tools image pins `@openai/codex@0.145.0`. The separate workflow latest lane resolves
 and probes `@latest` so reproducibility and drift detection remain independent.
 
 ## Other target assumptions

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -146,7 +146,7 @@ Every Codex subprocess has a finite timeout. On POSIX, each command starts in a 
 group; after a bounded SIGTERM grace period, timeout cleanup inspects and kills any remaining group
 even when the direct child exited first, then performs a bounded reap of the direct child. Non-POSIX
 platforms receive direct-child timeout cleanup only; ai-config 0.6.0 does not claim descendant
-cleanup there. The adapter accepts only the
-validated Codex 0.144.x JSON contract: malformed, partial, duplicate, inconsistent, or unknown
-version responses fail closed. Lifecycle failures retain ownership for retry, sanitize child output,
-name the exact stage and command, include remediation, and report completed and failed actions.
+cleanup there. The adapter accepts only the validated Codex 0.144.x and 0.145.x JSON contracts:
+malformed, partial, duplicate, inconsistent, or unknown version responses fail closed. Lifecycle
+failures retain ownership for retry, sanitize child output, name the exact stage and command,
+include remediation, and report completed and failed actions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-config-cli"
-version = "0.6.0"
+version = "0.6.1"
 description = "Declarative plugin manager for Claude Code"
 authors = [
     { name = "Alex Furrier", email = "afurrier@gmail.com" }

--- a/src/ai_config/__init__.py
+++ b/src/ai_config/__init__.py
@@ -1,3 +1,3 @@
 """ai-config: Declarative plugin manager for AI coding tools."""
 
-__version__ = "0.1.0"
+__version__ = "0.6.1"

--- a/src/ai_config/adapters/codex.py
+++ b/src/ai_config/adapters/codex.py
@@ -78,6 +78,7 @@ class CodexMarketplace:
 
     name: str
     root: Path
+    source_type: str | None
 
 
 @dataclass(frozen=True)
@@ -428,7 +429,13 @@ class CodexCLI:
                 detail = f"marketplaces[{index}].marketplaceSource and local root disagree"
                 raise self._schema_error("list-marketplaces", args, payload, detail, remediation)
             seen.add(name)
-            results.append(CodexMarketplace(name=name, root=Path(root).resolve()))
+            results.append(
+                CodexMarketplace(
+                    name=name,
+                    root=Path(root).resolve(),
+                    source_type=marketplace_source[0] if marketplace_source is not None else None,
+                )
+            )
         return results
 
     def add_marketplace(self, path: str, expected_name: str) -> CodexMarketplace:
@@ -461,7 +468,7 @@ class CodexCLI:
                 f"installedRoot does not match requested path {expected_root}",
                 remediation,
             )
-        return CodexMarketplace(name=name, root=expected_root)
+        return CodexMarketplace(name=name, root=expected_root, source_type="local")
 
     def remove_marketplace(self, name: str) -> None:
         self._ensure_supported_version()

--- a/src/ai_config/adapters/codex.py
+++ b/src/ai_config/adapters/codex.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 from ai_config.semver import SemanticVersion
 
-_SUPPORTED_CODEX_MAJOR_MINOR = (0, 144)
+_SUPPORTED_CODEX_MAJOR_MINORS = {(0, 144), (0, 145)}
+_SUPPORTED_CODEX_CONTRACT = "0.144.x or 0.145.x"
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 _TERMINATION_GRACE_SECONDS = 0.5
 _REAP_TIMEOUT_SECONDS = 0.5
@@ -255,8 +256,8 @@ class CodexCLI:
         if self._version is not None:
             return self._version
         remediation = (
-            "Install the Codex 0.144.x compatibility baseline or update ai-config's "
-            "Codex adapter and probes for the new CLI contract."
+            f"Install a supported Codex CLI ({_SUPPORTED_CODEX_CONTRACT}) or update "
+            "ai-config's Codex adapter and probes for the new CLI contract."
         )
         output = self._run("inspect-version", ["--version"], remediation=remediation)
         match = re.fullmatch(r"codex-cli (\S+)\s*", output.stdout)
@@ -281,14 +282,15 @@ class CodexCLI:
                 stderr=str(error),
                 remediation=remediation,
             ) from error
-        if (version.major, version.minor) != _SUPPORTED_CODEX_MAJOR_MINOR:
+        if (version.major, version.minor) not in _SUPPORTED_CODEX_MAJOR_MINORS:
             raise self._error(
                 "inspect-version",
                 ["--version"],
                 returncode=output.returncode,
                 stdout=output.stdout,
                 stderr=(
-                    f"unsupported Codex CLI response contract {version_text}; expected 0.144.x"
+                    f"unsupported Codex CLI response contract {version_text}; "
+                    f"expected {_SUPPORTED_CODEX_CONTRACT}"
                 ),
                 remediation=remediation,
             )
@@ -339,9 +341,37 @@ class CodexCLI:
             args,
             returncode=0,
             stdout=json.dumps(payload, sort_keys=True),
-            stderr=f"invalid Codex 0.144.x JSON response: {detail}",
+            stderr=f"invalid supported Codex JSON response: {detail}",
             remediation=remediation,
         )
+
+    def _optional_marketplace_source(
+        self,
+        entry: dict[str, object],
+        *,
+        field: str,
+        stage: str,
+        args: list[str],
+        payload: dict[str, object],
+        remediation: str,
+    ) -> tuple[str, str] | None:
+        if "marketplaceSource" not in entry:
+            return None
+        source = _as_object_dict(entry["marketplaceSource"])
+        if source is None:
+            detail = f"{field} must be an object when present"
+            raise self._schema_error(stage, args, payload, detail, remediation)
+        source_type = source.get("sourceType")
+        source_value = source.get("source")
+        if (
+            not isinstance(source_type, str)
+            or source_type not in _KNOWN_SOURCE_TYPES
+            or not isinstance(source_value, str)
+            or not source_value
+        ):
+            detail = f"{field} has an unknown source type or empty source"
+            raise self._schema_error(stage, args, payload, detail, remediation)
+        return source_type, source_value
 
     def list_marketplaces(self) -> list[CodexMarketplace]:
         self._ensure_supported_version()
@@ -368,7 +398,6 @@ class CodexCLI:
             entry = object_entry
             name = entry.get("name")
             root = entry.get("root")
-            source = entry.get("marketplaceSource")
             if not isinstance(name, str) or not name:
                 detail = f"marketplaces[{index}].name must be a non-empty string"
                 raise self._schema_error("list-marketplaces", args, payload, detail, remediation)
@@ -383,17 +412,20 @@ class CodexCLI:
             if not isinstance(root, str) or not root:
                 detail = f"marketplaces[{index}].root must be a non-empty string"
                 raise self._schema_error("list-marketplaces", args, payload, detail, remediation)
-            source_object = _as_object_dict(source)
-            if source_object is None:
-                detail = f"marketplaces[{index}].marketplaceSource must be an object"
-                raise self._schema_error("list-marketplaces", args, payload, detail, remediation)
-            source_type = source_object.get("sourceType")
-            source_value = source_object.get("source")
-            if source_type not in _KNOWN_SOURCE_TYPES or not isinstance(source_value, str):
-                detail = f"marketplaces[{index}] has an unknown marketplace source"
-                raise self._schema_error("list-marketplaces", args, payload, detail, remediation)
-            if source_type == "local" and Path(source_value).resolve() != Path(root).resolve():
-                detail = f"marketplaces[{index}] local root and source disagree"
+            marketplace_source = self._optional_marketplace_source(
+                entry,
+                field=f"marketplaces[{index}].marketplaceSource",
+                stage="list-marketplaces",
+                args=args,
+                payload=payload,
+                remediation=remediation,
+            )
+            if (
+                marketplace_source is not None
+                and marketplace_source[0] == "local"
+                and Path(marketplace_source[1]).resolve() != Path(root).resolve()
+            ):
+                detail = f"marketplaces[{index}].marketplaceSource and local root disagree"
                 raise self._schema_error("list-marketplaces", args, payload, detail, remediation)
             seen.add(name)
             results.append(CodexMarketplace(name=name, root=Path(root).resolve()))
@@ -472,7 +504,6 @@ class CodexCLI:
         marketplace_name = object_entry.get("marketplaceName")
         version = object_entry.get("version")
         source = _as_object_dict(object_entry.get("source"))
-        marketplace_source = _as_object_dict(object_entry.get("marketplaceSource"))
         if (
             not isinstance(plugin_id, str)
             or not plugin_id
@@ -509,12 +540,6 @@ class CodexCLI:
             ) from error
         source_type = source.get("source") if source is not None else None
         source_path = source.get("path") if source is not None else None
-        marketplace_source_type = (
-            marketplace_source.get("sourceType") if marketplace_source is not None else None
-        )
-        marketplace_source_value = (
-            marketplace_source.get("source") if marketplace_source is not None else None
-        )
         if source_type not in _KNOWN_SOURCE_TYPES:
             detail = f"available[{index}].source has an unknown source type"
             raise self._schema_error("list-plugins", args, payload, detail, remediation)
@@ -526,21 +551,26 @@ class CodexCLI:
         ):
             detail = f"available[{index}].source.url must be a non-empty string"
             raise self._schema_error("list-plugins", args, payload, detail, remediation)
+        marketplace_source = self._optional_marketplace_source(
+            object_entry,
+            field=f"available[{index}].marketplaceSource",
+            stage="list-plugins",
+            args=args,
+            payload=payload,
+            remediation=remediation,
+        )
         if (
-            marketplace_source_type not in _KNOWN_SOURCE_TYPES
-            or not isinstance(marketplace_source_value, str)
-            or not marketplace_source_value
+            source_type == "local"
+            and marketplace_source is not None
+            and marketplace_source[0] == "local"
         ):
-            detail = f"available[{index}].marketplaceSource has an unknown source type"
-            raise self._schema_error("list-plugins", args, payload, detail, remediation)
-        if source_type == "local" and marketplace_source_type == "local":
             if not isinstance(source_path, str):
                 detail = f"available[{index}].source.path must be a non-empty string"
                 raise self._schema_error("list-plugins", args, payload, detail, remediation)
             source_root = Path(source_path).resolve()
-            marketplace_root = Path(marketplace_source_value).resolve()
+            marketplace_root = Path(marketplace_source[1]).resolve()
             if marketplace_root not in source_root.parents:
-                detail = f"available[{index}] plugin source is outside its marketplace root"
+                detail = f"available[{index}] plugin source is outside its marketplaceSource root"
                 raise self._schema_error("list-plugins", args, payload, detail, remediation)
         return plugin_id
 
@@ -597,7 +627,6 @@ class CodexCLI:
             version = entry.get("version")
             enabled = entry.get("enabled")
             source = entry.get("source")
-            marketplace_source = entry.get("marketplaceSource")
             if (
                 not isinstance(plugin_id, str)
                 or not plugin_id
@@ -664,23 +693,17 @@ class CodexCLI:
             resolved_source = (
                 Path(source_path_value).resolve() if isinstance(source_path_value, str) else None
             )
-            marketplace_source_object = _as_object_dict(marketplace_source)
-            marketplace_source_value = (
-                marketplace_source_object.get("source")
-                if marketplace_source_object is not None
-                else None
+            marketplace_source = self._optional_marketplace_source(
+                entry,
+                field=f"installed[{index}].marketplaceSource",
+                stage="list-plugins",
+                args=args,
+                payload=payload,
+                remediation=remediation,
             )
-            if (
-                marketplace_source_object is None
-                or marketplace_source_object.get("sourceType") not in _KNOWN_SOURCE_TYPES
-                or not isinstance(marketplace_source_value, str)
-            ):
-                detail = f"installed[{index}].marketplaceSource has an unknown source type"
-                raise self._schema_error("list-plugins", args, payload, detail, remediation)
-            marketplace_source_type = marketplace_source_object.get("sourceType")
             marketplace_root = (
-                Path(marketplace_source_value).resolve()
-                if marketplace_source_type == "local"
+                Path(marketplace_source[1]).resolve()
+                if marketplace_source is not None and marketplace_source[0] == "local"
                 else None
             )
             if (
@@ -688,7 +711,7 @@ class CodexCLI:
                 and resolved_source is not None
                 and marketplace_root not in resolved_source.parents
             ):
-                detail = f"installed[{index}] plugin source is outside its marketplace root"
+                detail = f"installed[{index}] plugin source is outside its marketplaceSource root"
                 raise self._schema_error("list-plugins", args, payload, detail, remediation)
             seen.add(plugin_id)
             results.append(

--- a/src/ai_config/codex_lifecycle.py
+++ b/src/ai_config/codex_lifecycle.py
@@ -326,10 +326,13 @@ def _plan_actions(
         entry = previous[plugin_id]
         removal_reason = removal_reasons.get(plugin_id, default_removal_reason)
         marketplace = marketplaces.get(entry.marketplace_name)
-        if marketplace is not None and marketplace.root != entry.marketplace_path:
+        if marketplace is not None and (
+            marketplace.root != entry.marketplace_path or marketplace.source_type != "local"
+        ):
             raise ValueError(
                 f"Codex marketplace ownership changed for '{entry.marketplace_name}': "
-                f"registered root is {marketplace.root}, expected {entry.marketplace_path}. "
+                f"registered root/source is {marketplace.root} ({marketplace.source_type}), "
+                f"expected local {entry.marketplace_path}. "
                 "ai-config will not remove the marketplace or plugin. Resolve the collision and retry."
             )
         installed = plugins.get(plugin_id)
@@ -380,10 +383,13 @@ def _plan_actions(
                     f"Generated marketplace is not registered at {spec.marketplace_path}",
                 )
             )
-        elif marketplace is not None and marketplace.root != spec.marketplace_path:
+        elif marketplace is not None and (
+            marketplace.root != spec.marketplace_path or marketplace.source_type != "local"
+        ):
             raise ValueError(
                 f"Codex marketplace name collision for '{spec.marketplace_name}': "
-                f"registered root is {marketplace.root}, expected {spec.marketplace_path}. "
+                f"registered root/source is {marketplace.root} ({marketplace.source_type}), "
+                f"expected local {spec.marketplace_path}. "
                 "ai-config will not modify the unrelated marketplace. Rename/remove the collision and retry."
             )
 

--- a/tests/docker/Dockerfile.all-tools
+++ b/tests/docker/Dockerfile.all-tools
@@ -43,7 +43,7 @@ RUN npm install -g @anthropic-ai/claude-code
 
 # 2. OpenAI Codex - pinned package contract for reproducible plugin lifecycle E2E.
 # The separate latest-Codex workflow lane resolves the registry tag at execution time.
-ARG CODEX_VERSION=0.144.5
+ARG CODEX_VERSION=0.145.0
 RUN npm install -g "@openai/codex@${CODEX_VERSION}"
 
 # 3. OpenCode - npm package (opencode-ai)

--- a/tests/e2e/test_tool_validation.py
+++ b/tests/e2e/test_tool_validation.py
@@ -152,7 +152,7 @@ class TestCodexToolValidation:
     def test_codex_pinned_version(self, all_tools_container: Container) -> None:
         exit_code, output = exec_in_container(all_tools_container, "codex --version")
         assert exit_code == 0, f"Codex CLI not available: {output}"
-        assert "0.144.5" in output
+        assert "0.145.0" in output
 
     def test_generated_package_full_lifecycle(self, all_tools_container: Container) -> None:
         """The pinned all-tools lane proves install, discovery, update, and removal."""
@@ -161,7 +161,7 @@ class TestCodexToolValidation:
             "codex_bin=$(command -v codex) && "
             "env -u OPENAI_API_KEY -u CODEX_API_KEY -u CHATGPT_API_KEY "
             "uv run python tests/probes/probe_codex_plugin_package.py "
-            '--codex "$codex_bin" --expected-version 0.144.5',
+            '--codex "$codex_bin" --expected-version 0.145.0',
         )
         assert exit_code == 0, f"Codex package lifecycle probe failed: {output}"
         assert '"result": "passed"' in output

--- a/tests/probes/probe_ai_config_sync_codex.py
+++ b/tests/probes/probe_ai_config_sync_codex.py
@@ -23,6 +23,8 @@ from probe_codex_plugin_package import (
 )
 
 _MANAGED_PLUGIN_ID = "dev-tools@ai-config-dev-tools"
+_SOURCE_LESS_MARKETPLACE = "source-less-marketplace"
+_SOURCE_LESS_PLUGIN_ID = f"source-less-plugin@{_SOURCE_LESS_MARKETPLACE}"
 
 
 def _write_fake_claude(path: Path, plugin_path: Path, marketplace_path: Path) -> None:
@@ -86,6 +88,38 @@ def _write_config(path: Path, marketplace_path: Path, output_path: Path, *, enab
         ],
     }
     path.write_text(yaml.safe_dump(payload, sort_keys=False))
+
+
+def _write_source_less_catalog(codex_home: Path) -> None:
+    marketplace = codex_home / ".tmp/plugins"
+    plugin = marketplace / "plugins/source-less-plugin"
+    (marketplace / ".agents/plugins").mkdir(parents=True)
+    (plugin / ".codex-plugin").mkdir(parents=True)
+    (marketplace / ".agents/plugins/marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": _SOURCE_LESS_MARKETPLACE,
+                "plugins": [
+                    {
+                        "name": "source-less-plugin",
+                        "source": {
+                            "source": "local",
+                            "path": "./plugins/source-less-plugin",
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    (plugin / ".codex-plugin/plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "source-less-plugin",
+                "version": "1.0.0",
+                "description": "unrelated source-less catalog state",
+            }
+        )
+    )
 
 
 def _run_ai_config(config: Path, env: dict[str, str], *extra: str) -> dict[str, object]:
@@ -161,6 +195,42 @@ def _assert_prompt_marker(codex: str, env: dict[str, str], output: Path, marker:
         raise AssertionError(f"public sync package marker was not discovered: {marker}")
 
 
+def _source_less_catalog_state(codex: str, env: dict[str, str]) -> set[tuple[str, str]]:
+    marketplaces = load_json(run(codex, ["plugin", "marketplace", "list", "--json"], env)).get(
+        "marketplaces"
+    )
+    if not isinstance(marketplaces, list):
+        raise AssertionError("Codex source-less marketplace probe did not return an array")
+    marketplace_names = {
+        entry["name"]
+        for entry in marketplaces
+        if isinstance(entry, dict)
+        and "marketplaceSource" not in entry
+        and isinstance(entry.get("name"), str)
+    }
+    if not marketplace_names:
+        raise AssertionError("Codex catalog did not expose a source-less marketplace row")
+
+    available = load_json(run(codex, ["plugin", "list", "--available", "--json"], env)).get(
+        "available"
+    )
+    if not isinstance(available, list):
+        raise AssertionError("Codex source-less plugin probe did not return an available array")
+    catalog_pairs = {
+        (entry["marketplaceName"], entry["pluginId"])
+        for entry in available
+        if isinstance(entry, dict)
+        and "marketplaceSource" not in entry
+        and entry.get("marketplaceName") in marketplace_names
+        and isinstance(entry.get("marketplaceName"), str)
+        and isinstance(entry.get("pluginId"), str)
+    }
+    if not catalog_pairs:
+        raise AssertionError("Codex catalog did not expose a source-less available-plugin row")
+
+    return catalog_pairs
+
+
 def probe(codex: str) -> dict[str, object]:
     repo_root = Path(__file__).resolve().parents[2]
     source_fixture = repo_root / "tests/fixtures/sample-plugins/complete-plugin"
@@ -202,6 +272,13 @@ def probe(codex: str) -> dict[str, object]:
         load_json(run(codex, ["plugin", "marketplace", "add", unrelated_path, "--json"], env))
         load_json(run(codex, ["plugin", "add", unrelated_id, "--json"], env))
         set_enabled(codex_home / "config.toml", unrelated_id, False)
+        _write_source_less_catalog(codex_home)
+        source_less_catalog_entry = (_SOURCE_LESS_MARKETPLACE, _SOURCE_LESS_PLUGIN_ID)
+        if source_less_catalog_entry not in _source_less_catalog_state(codex, env):
+            raise AssertionError(
+                "Codex did not expose the constructed source-less catalog state: "
+                f"{source_less_catalog_entry}"
+            )
 
         first = _actions(_run_ai_config(config, env))
         if not {"register_codex_marketplace", "install_codex_plugin"} <= set(first):
@@ -288,6 +365,11 @@ def probe(codex: str) -> dict[str, object]:
         }
         if "ai-config-dev-tools" in names or "user-marketplace" not in names:
             raise AssertionError(f"public removal did not preserve unrelated marketplace: {names}")
+        if source_less_catalog_entry not in _source_less_catalog_state(codex, env):
+            raise AssertionError(
+                "public sync removed unrelated source-less catalog state: "
+                f"{source_less_catalog_entry}"
+            )
         final_config = config_path.read_text()
         if 'model = "preserve-public-sync"' not in final_config:
             raise AssertionError("public sync clobbered unrelated scalar config")
@@ -308,6 +390,7 @@ def probe(codex: str) -> dict[str, object]:
             "missing-drift-install",
             "owned-removal",
             "unrelated-state-preservation",
+            "source-less-catalog-preservation",
         ],
     }
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -68,7 +68,7 @@ class TestMainGroup:
         """Shows version info."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.6.0" in result.output
+        assert "0.6.1" in result.output
 
     def test_help(self, runner: CliRunner) -> None:
         """Shows help text."""

--- a/tests/unit/test_codex_lifecycle.py
+++ b/tests/unit/test_codex_lifecycle.py
@@ -68,7 +68,7 @@ class FakeCodexCLI:
 
     def add_marketplace(self, path: str, expected_name: str) -> CodexMarketplace:
         self.calls.append(("add_marketplace", path, expected_name))
-        return CodexMarketplace(expected_name, Path(path).resolve())
+        return CodexMarketplace(expected_name, Path(path).resolve(), source_type="local")
 
     def remove_marketplace(self, name: str) -> None:
         self.calls.append(("remove_marketplace", name))
@@ -121,7 +121,7 @@ def _package(
 
 
 def _marketplace(spec) -> CodexMarketplace:
-    return CodexMarketplace(spec.marketplace_name, spec.marketplace_path)
+    return CodexMarketplace(spec.marketplace_name, spec.marketplace_path, source_type="local")
 
 
 def _installed(spec, *, enabled: bool = True, version: str | None = None) -> CodexInstalledPlugin:
@@ -409,7 +409,13 @@ def test_symlinked_marketplace_ancestor_cannot_redirect_lifecycle_cleanup(
     sentinel = external_package / "sentinel"
     sentinel.write_text("outside")
     cli = FakeCodexCLI(
-        marketplaces=[CodexMarketplace(spec.marketplace_name, external_package.resolve())]
+        marketplaces=[
+            CodexMarketplace(
+                spec.marketplace_name,
+                external_package.resolve(),
+                source_type="local",
+            )
+        ]
     )
 
     with pytest.raises(ValueError, match="symlink"):
@@ -477,7 +483,10 @@ def test_removal_touches_only_owned_state(tmp_path: Path) -> None:
     unrelated.write_text('model = "keep"\n')
     user_root = Path("/user/market").resolve()
     cli = FakeCodexCLI(
-        marketplaces=[_marketplace(spec), CodexMarketplace("user-market", user_root)],
+        marketplaces=[
+            _marketplace(spec),
+            CodexMarketplace("user-market", user_root, source_type="local"),
+        ],
         plugins=[
             _installed(spec),
             CodexInstalledPlugin(
@@ -534,6 +543,36 @@ def test_sourceless_plugin_collision_fails_before_mutation(tmp_path: Path) -> No
     assert cli.calls == []
 
 
+@pytest.mark.parametrize("owned", [False, True])
+def test_sourceless_marketplace_collision_fails_before_mutation(
+    tmp_path: Path, owned: bool
+) -> None:
+    spec = _package(tmp_path)
+    desired = [spec]
+    if owned:
+        _establish_ownership(spec, tmp_path)
+        desired = []
+    cli = FakeCodexCLI(
+        marketplaces=[
+            CodexMarketplace(
+                name=spec.marketplace_name,
+                root=spec.marketplace_path,
+                source_type=None,
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="marketplace (name collision|ownership changed)"):
+        sync_codex_packages(
+            desired,
+            output_dir=tmp_path,
+            refreshed_plugin_ids={spec.plugin_id} if desired else set(),
+            cli=cli,
+        )
+
+    assert cli.calls == []
+
+
 def test_validated_output_migration_plans_replacement_state(tmp_path: Path) -> None:
     old_root = tmp_path / "old"
     new_root = tmp_path / "new"
@@ -570,7 +609,9 @@ def test_validated_output_migration_plans_replacement_state(tmp_path: Path) -> N
 @pytest.mark.parametrize("root", [Path("/unrelated"), Path("/unknown")])
 def test_marketplace_name_collision_fails_closed(tmp_path: Path, root: Path) -> None:
     spec = _package(tmp_path)
-    cli = FakeCodexCLI(marketplaces=[CodexMarketplace(spec.marketplace_name, root)])
+    cli = FakeCodexCLI(
+        marketplaces=[CodexMarketplace(spec.marketplace_name, root, source_type="local")]
+    )
     with pytest.raises(ValueError, match="will not modify"):
         sync_codex_packages(
             [spec], output_dir=tmp_path, refreshed_plugin_ids={spec.plugin_id}, cli=cli
@@ -744,6 +785,7 @@ def test_cli_accepts_absent_marketplace_source_metadata(
     assert marketplace == CodexMarketplace(
         name="openai-curated",
         root=Path("/cache/openai-curated"),
+        source_type=None,
     )
     assert installed.source_path == Path("/cache/openai-curated/plugins/installed")
     assert installed.marketplace_root is None
@@ -991,7 +1033,7 @@ def test_cli_supported_versions_accept_observed_contract(tmp_path: Path, version
     executable = tmp_path / f"codex-version-{version}"
     executable.write_text(
         "#!/bin/sh\n"
-        f"if [ \"$1\" = \"--version\" ]; then echo 'codex-cli {version}'; exit 0; fi\n"
+        f'if [ "$1" = "--version" ]; then echo \'codex-cli {version}\'; exit 0; fi\n'
         "printf '%s' '{\"marketplaces\":[]}'\n"
     )
     executable.chmod(executable.stat().st_mode | stat.S_IXUSR)

--- a/tests/unit/test_codex_lifecycle.py
+++ b/tests/unit/test_codex_lifecycle.py
@@ -487,7 +487,7 @@ def test_removal_touches_only_owned_state(tmp_path: Path) -> None:
                 version="1.0.0",
                 enabled=False,
                 source_path=user_root / "plugins/user",
-                marketplace_root=user_root,
+                marketplace_root=None,
             ),
         ],
     )
@@ -504,6 +504,34 @@ def test_removal_touches_only_owned_state(tmp_path: Path) -> None:
         ("remove_marketplace", spec.marketplace_name),
     ]
     assert unrelated.read_text() == 'model = "keep"\n'
+
+
+def test_sourceless_plugin_collision_fails_before_mutation(tmp_path: Path) -> None:
+    spec = _package(tmp_path)
+    installed = _installed(spec)
+    sourceless_collision = CodexInstalledPlugin(
+        plugin_id=installed.plugin_id,
+        name=installed.name,
+        marketplace_name=installed.marketplace_name,
+        version=installed.version,
+        enabled=installed.enabled,
+        source_path=installed.source_path,
+        marketplace_root=None,
+    )
+    cli = FakeCodexCLI(
+        marketplaces=[_marketplace(spec)],
+        plugins=[sourceless_collision],
+    )
+
+    with pytest.raises(ValueError, match="identity collision"):
+        sync_codex_packages(
+            [spec],
+            output_dir=tmp_path,
+            refreshed_plugin_ids={spec.plugin_id},
+            cli=cli,
+        )
+
+    assert cli.calls == []
 
 
 def test_validated_output_migration_plans_replacement_state(tmp_path: Path) -> None:
@@ -657,6 +685,126 @@ def test_cli_available_rows_require_complete_typed_identity(
             cli.list_plugins()
 
 
+def test_cli_accepts_absent_marketplace_source_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = CodexCLI("/bin/codex")
+    monkeypatch.setattr(cli, "_ensure_supported_version", lambda: "0.144.5")
+    responses = iter(
+        [
+            {
+                "marketplaces": [
+                    {
+                        "name": "openai-curated",
+                        "root": "/cache/openai-curated",
+                    }
+                ]
+            },
+            {
+                "installed": [
+                    {
+                        "pluginId": "installed@openai-curated",
+                        "name": "installed",
+                        "marketplaceName": "openai-curated",
+                        "version": "1.0.0",
+                        "installed": True,
+                        "enabled": True,
+                        "source": {
+                            "source": "local",
+                            "path": "/cache/openai-curated/plugins/installed",
+                        },
+                        "installPolicy": "AVAILABLE",
+                        "authPolicy": "ON_INSTALL",
+                    }
+                ],
+                "available": [
+                    {
+                        "pluginId": "available@openai-curated",
+                        "name": "available",
+                        "marketplaceName": "openai-curated",
+                        "version": "2.0.0",
+                        "installed": False,
+                        "enabled": False,
+                        "source": {
+                            "source": "local",
+                            "path": "/cache/openai-curated/plugins/available",
+                        },
+                        "installPolicy": "AVAILABLE",
+                        "authPolicy": "ON_INSTALL",
+                    }
+                ],
+            },
+        ]
+    )
+    monkeypatch.setattr(cli, "run_json", lambda *args, **kwargs: next(responses))
+
+    marketplace = cli.list_marketplaces()[0]
+    installed = cli.list_plugins()[0]
+
+    assert marketplace == CodexMarketplace(
+        name="openai-curated",
+        root=Path("/cache/openai-curated"),
+    )
+    assert installed.source_path == Path("/cache/openai-curated/plugins/installed")
+    assert installed.marketplace_root is None
+
+
+@pytest.mark.parametrize(
+    "marketplace_source",
+    [
+        None,
+        [],
+        "local",
+        {},
+        {"sourceType": "unknown", "source": "/market"},
+        {"sourceType": "local", "source": ""},
+        {"sourceType": "local", "source": "/other-market"},
+    ],
+)
+@pytest.mark.parametrize("row_kind", ["marketplace", "available", "installed"])
+def test_cli_rejects_present_malformed_marketplace_source(
+    monkeypatch: pytest.MonkeyPatch,
+    marketplace_source: object,
+    row_kind: str,
+) -> None:
+    cli = CodexCLI("/bin/codex")
+    monkeypatch.setattr(cli, "_ensure_supported_version", lambda: "0.144.5")
+    plugin_row = {
+        "pluginId": "demo@market",
+        "name": "demo",
+        "marketplaceName": "market",
+        "version": "1.0.0",
+        "installed": row_kind == "installed",
+        "enabled": row_kind == "installed",
+        "source": {"source": "local", "path": "/market/plugins/demo"},
+        "marketplaceSource": marketplace_source,
+        "installPolicy": "AVAILABLE",
+        "authPolicy": "ON_INSTALL",
+    }
+    if row_kind == "marketplace":
+        payload = {
+            "marketplaces": [
+                {
+                    "name": "market",
+                    "root": "/market",
+                    "marketplaceSource": marketplace_source,
+                }
+            ]
+        }
+        monkeypatch.setattr(cli, "run_json", lambda *args, **kwargs: payload)
+        operation = cli.list_marketplaces
+    else:
+        payload = {
+            "installed": [plugin_row] if row_kind == "installed" else [],
+            "available": [plugin_row] if row_kind == "available" else [],
+        }
+        monkeypatch.setattr(cli, "run_json", lambda *args, **kwargs: payload)
+        operation = cli.list_plugins
+
+    with pytest.raises(CodexCommandError, match="marketplaceSource"):
+        operation()
+
+
 def test_cli_preserves_typed_nonlocal_unrelated_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -725,7 +873,7 @@ def test_cli_marketplace_list_schema_rejects_wrong_shape(
     monkeypatch.setattr(cli, "_ensure_supported_version", lambda: "0.144.5")
     monkeypatch.setattr(cli, "run_json", lambda *args, **kwargs: payload)
 
-    with pytest.raises(CodexCommandError, match="invalid Codex 0.144.x JSON response"):
+    with pytest.raises(CodexCommandError, match="invalid supported Codex JSON response"):
         cli.list_marketplaces()
 
 
@@ -838,9 +986,22 @@ def test_cli_mutation_schema_rejects_semantically_wrong_success(
         cli.remove_plugin("demo@market")
 
 
+@pytest.mark.parametrize("version", ["0.144.5", "0.145.0"])
+def test_cli_supported_versions_accept_observed_contract(tmp_path: Path, version: str) -> None:
+    executable = tmp_path / f"codex-version-{version}"
+    executable.write_text(
+        "#!/bin/sh\n"
+        f"if [ \"$1\" = \"--version\" ]; then echo 'codex-cli {version}'; exit 0; fi\n"
+        "printf '%s' '{\"marketplaces\":[]}'\n"
+    )
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+    assert CodexCLI(str(executable)).list_marketplaces() == []
+
+
 def test_cli_unknown_version_fails_closed(tmp_path: Path) -> None:
     executable = tmp_path / "codex-version"
-    executable.write_text("#!/bin/sh\necho 'codex-cli 0.145.0'\n")
+    executable.write_text("#!/bin/sh\necho 'codex-cli 0.146.0'\n")
     executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
 
     with pytest.raises(CodexCommandError, match="unsupported Codex CLI response contract"):

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -9,8 +9,21 @@ def test_0_6_0_release_metadata_is_finalized() -> None:
     changelog = (_REPO_ROOT / "CHANGELOG.md").read_text()
 
     assert "## [0.6.0] - 2026-07-17" in changelog
-    assert "[Unreleased]: https://github.com/safurrier/ai-config/compare/v0.6.0...HEAD" in changelog
     assert "[0.6.0]: https://github.com/safurrier/ai-config/compare/v0.5.0...v0.6.0" in changelog
+
+
+def test_0_6_1_release_metadata_is_finalized() -> None:
+    changelog = (_REPO_ROOT / "CHANGELOG.md").read_text()
+    pyproject = (_REPO_ROOT / "pyproject.toml").read_text()
+    package_init = (_REPO_ROOT / "src/ai_config/__init__.py").read_text()
+    lockfile = (_REPO_ROOT / "uv.lock").read_text()
+
+    assert 'version = "0.6.1"' in pyproject
+    assert '__version__ = "0.6.1"' in package_init
+    assert 'name = "ai-config-cli"\nversion = "0.6.1"' in lockfile
+    assert "## [0.6.1] - 2026-07-24" in changelog
+    assert "[Unreleased]: https://github.com/safurrier/ai-config/compare/v0.6.1...HEAD" in changelog
+    assert "[0.6.1]: https://github.com/safurrier/ai-config/compare/v0.6.0...v0.6.1" in changelog
 
 
 def test_release_checklist_assigns_date_at_release_time() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ai-config-cli"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Codex can return valid marketplace and plugin catalog rows without `marketplaceSource`. ai-config 0.6.0 treated absence as malformed JSON, so `sync --dry-run` failed before lifecycle planning against the current catalog.

This change distinguishes an absent field from a present malformed value across marketplace, available-plugin, and installed-plugin rows. Source-less installed plugins keep their plugin source but do not receive an inferred marketplace root, so desired and previously owned identity collisions still fail before mutation. Present null, non-object, unknown, empty, inconsistent, and path-escaping metadata remains rejected.

The release also adds the runtime-verified Codex 0.145.x contract, pins 0.145.0 in the all-tools image, and prepares ai-config 0.6.1.

### Runtime proof

- The current Codex 0.144.5 catalog now completes a real personal-config dry-run without changing Codex configuration.
- Isolated 0.144.5 public-sync coverage constructs and preserves an unrelated source-less marketplace/plugin through install, repair, update, and removal.
- The integrity-verified `@openai/codex@latest` 0.145.0 package and public-sync probes pass without credentials.
- Focused regressions cover absent versus malformed metadata, unrelated-state preservation, collision safety, supported-version guards, and release metadata.

Local CI parity passed 716 tests with coverage. One unchanged macOS hostile-descendant setup test fails identically on `main`; the PR’s Linux unit job remains the deciding evidence. Local Docker was unavailable, so the PR’s pinned all-tools E2E job must pass before merge.

Fixes #20
