### PR TITLE
Own and reconcile generated Pi conversion output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pi sync now records ai-config-owned generated files with source identity and content digests, reconciles disabled/removed Pi output safely, and reports create/update/remove/no-op/local-modification actions without adopting historical unowned output.
+
 ## [0.6.1] - 2026-07-24
 
 ### Fixed

--- a/src/ai_config/cli.py
+++ b/src/ai_config/cli.py
@@ -345,7 +345,7 @@ def status(
                 }
                 for drift_result in (drift_results or {}).values()
                 for action in drift_result.actions_taken
-                if action.action != "noop_codex_plugin"
+                if action.action not in {"noop_codex_plugin", "noop_pi_output"}
             ],
             "errors": result.errors
             + [
@@ -403,7 +403,7 @@ def status(
             action
             for drift_result in drift_results.values()
             for action in drift_result.actions_taken
-            if action.action != "noop_codex_plugin"
+            if action.action not in {"noop_codex_plugin", "noop_pi_output"}
         ]
         if planned_actions:
             table = Table(show_header=True, header_style="bold", box=None)

--- a/src/ai_config/cli.py
+++ b/src/ai_config/cli.py
@@ -981,6 +981,14 @@ def convert(
     else:
         target_list = [TargetTool(t) for t in targets]
 
+    # Standalone Pi writes cannot safely establish the multi-plugin ownership ledger.
+    # Pi output is therefore managed only through `ai-config sync`.
+    if TargetTool.PI in target_list and not dry_run:
+        raise click.UsageError(
+            "Standalone Pi conversion is disabled: use ai-config sync with a Pi conversion target "
+            "so generated files are recorded in the ownership ledger."
+        )
+
     # Use scope-based output resolution if no output specified
     if output_dir is None:
         output_dir = Path.home() if scope == "user" else Path.cwd()

--- a/src/ai_config/cli.py
+++ b/src/ai_config/cli.py
@@ -973,7 +973,7 @@ def convert(
       pi         Pi (skills, prompt templates, supported hook extensions)
       all        All of the above (default)
     """
-    from ai_config.converters import InstallScope, TargetTool, convert_plugin, preview_conversion
+    from ai_config.converters import InstallScope, TargetTool, convert_plugin
 
     # Resolve targets
     if "all" in targets:
@@ -981,38 +981,15 @@ def convert(
     else:
         target_list = [TargetTool(t) for t in targets]
 
-    # Standalone Pi writes cannot safely establish the multi-plugin ownership ledger.
-    # Pi output is therefore managed only through `ai-config sync`.
-    if TargetTool.PI in target_list and not dry_run:
-        raise click.UsageError(
-            "Standalone Pi conversion is disabled: use ai-config sync with a Pi conversion target "
-            "so generated files are recorded in the ownership ledger."
-        )
-
     # Use scope-based output resolution if no output specified
     if output_dir is None:
         output_dir = Path.home() if scope == "user" else Path.cwd()
     install_scope = InstallScope(scope)
 
-    if dry_run:
-        # Just preview
-        console.print()
-        console.print(
-            Panel.fit("[header]ai-config convert (preview)[/header]", border_style="cyan")
-        )
-        console.print()
-        preview = preview_conversion(
-            plugin_path,
-            target_list,
-            output_dir,
-            scope=install_scope,
-        )
-        console.print(preview)
-        return
-
-    # Perform conversion
+    # Perform conversion or report its ownership-aware plan.
     console.print()
-    console.print(Panel.fit("[header]ai-config convert[/header]", border_style="cyan"))
+    title = "ai-config convert (preview)" if dry_run else "ai-config convert"
+    console.print(Panel.fit(f"[header]{title}[/header]", border_style="cyan"))
     console.print()
 
     with Progress(
@@ -1027,7 +1004,7 @@ def convert(
             targets=target_list,
             output_dir=output_dir,
             scope=install_scope,
-            dry_run=False,
+            dry_run=dry_run,
             best_effort=best_effort,
         )
 
@@ -1067,9 +1044,11 @@ def convert(
 
             # Show files
             if report.files_written:
-                console.print(f"\n[info]Files created ({len(report.files_written)}):[/info]")
+                label = "Files planned" if dry_run else "File actions"
+                console.print(f"\n[info]{label} ({len(report.files_written)}):[/info]")
                 for f in report.files_written:
-                    console.print(f"  {SYMBOLS['arrow']} {f.path}")
+                    reason = f" - {f.reason}" if f.reason else ""
+                    console.print(f"  {SYMBOLS['arrow']} {f.action}: {f.path}{reason}")
 
         if report.has_errors():
             any_errors = True

--- a/src/ai_config/converters/convert.py
+++ b/src/ai_config/converters/convert.py
@@ -156,7 +156,11 @@ def _convert_to_target(
         ]
         retained_sources = _standalone_pi_retained_sources(output_dir, source_plugin)
         actions = apply_pi_reconciliation(
-            output_dir, desired, dry_run=dry_run, retained_sources=retained_sources
+            output_dir,
+            desired,
+            dry_run=dry_run,
+            retained_sources=retained_sources,
+            ownership_domain="standalone",
         )
         desired_sizes = {item.relative_path: len(item.content) for item in desired}
         for item in actions:
@@ -235,7 +239,9 @@ def convert_plugin_simple(
                 for file in result.files
             ]
             retained_sources = _standalone_pi_retained_sources(root, source_plugin)
-            apply_pi_reconciliation(root, desired, retained_sources=retained_sources)
+            apply_pi_reconciliation(
+                root, desired, retained_sources=retained_sources, ownership_domain="standalone"
+            )
         else:
             result.write_to(Path(output_dir))
 

--- a/src/ai_config/converters/convert.py
+++ b/src/ai_config/converters/convert.py
@@ -66,7 +66,14 @@ def convert_plugin(
             reports[target] = report
         return reports
 
-    # Convert to each target
+    # Validate Pi ownership before any target can mutate the shared output root.
+    # Dry runs already use the reconciliation planner as their sole non-mutating
+    # operation, so only mutating conversions need this separate preflight.
+    pi_result: EmitResult | None = None
+    if output_dir is not None and not dry_run and TargetTool.PI in targets:
+        pi_result = _preflight_pi_reconciliation(ir, plugin_path, output_dir, scope)
+
+    # Preserve the caller's requested report order after the Pi preflight succeeds.
     reports = {}
     for target in targets:
         report = _convert_to_target(
@@ -77,10 +84,46 @@ def convert_plugin(
             scope=scope,
             dry_run=dry_run,
             best_effort=best_effort,
+            emit_result=pi_result if target == TargetTool.PI else None,
         )
         reports[target] = report
 
     return reports
+
+
+def _pi_reconciliation_inputs(
+    ir: PluginIR, source_path: Path, result: EmitResult
+) -> tuple[str, list[PiDesiredFile]]:
+    """Build the ownership inputs shared by Pi preflight and application."""
+    source_plugin = standalone_pi_source_identity(source_path, ir.identity.plugin_id)
+    desired = [
+        PiDesiredFile(
+            source_plugin,
+            file.path,
+            file.content.encode("utf-8") if isinstance(file.content, str) else file.content,
+            file.executable,
+        )
+        for file in result.files
+    ]
+    return source_plugin, desired
+
+
+def _preflight_pi_reconciliation(
+    ir: PluginIR, source_path: Path, output_dir: Path, scope: InstallScope
+) -> EmitResult:
+    """Plan Pi reconciliation without changing disk before other targets write."""
+    result = get_emitter(TargetTool.PI, scope).emit(ir)
+    if any(diagnostic.severity == Severity.ERROR for diagnostic in result.diagnostics):
+        raise ValueError("Pi conversion preflight has blocking emitter diagnostics")
+    source_plugin, desired = _pi_reconciliation_inputs(ir, source_path, result)
+    apply_pi_reconciliation(
+        output_dir,
+        desired,
+        dry_run=True,
+        retained_sources=_standalone_pi_retained_sources(output_dir, source_plugin),
+        ownership_domain="standalone",
+    )
+    return result
 
 
 def _convert_to_target(
@@ -91,6 +134,7 @@ def _convert_to_target(
     scope: InstallScope,
     dry_run: bool,
     best_effort: bool,
+    emit_result: EmitResult | None = None,
 ) -> ConversionReport:
     """Convert IR to a single target format."""
     report = ConversionReport(
@@ -108,8 +152,7 @@ def _convert_to_target(
 
     # Get emitter and emit
     try:
-        emitter = get_emitter(target, scope)
-        result = emitter.emit(ir)
+        result = emit_result or get_emitter(target, scope).emit(ir)
     except Exception as e:
         if best_effort:
             from ai_config.converters.ir import Diagnostic
@@ -144,16 +187,7 @@ def _convert_to_target(
     # standalone conversion remove only this plugin's stale files while retaining
     # projections from other plugins at the same root.
     if output_dir and target == TargetTool.PI:
-        source_plugin = standalone_pi_source_identity(source_path, ir.identity.plugin_id)
-        desired = [
-            PiDesiredFile(
-                source_plugin,
-                file.path,
-                file.content.encode("utf-8") if isinstance(file.content, str) else file.content,
-                file.executable,
-            )
-            for file in result.files
-        ]
+        source_plugin, desired = _pi_reconciliation_inputs(ir, source_path, result)
         retained_sources = _standalone_pi_retained_sources(output_dir, source_plugin)
         actions = apply_pi_reconciliation(
             output_dir,

--- a/src/ai_config/converters/convert.py
+++ b/src/ai_config/converters/convert.py
@@ -12,21 +12,17 @@ from ai_config.converters.claude_parser import parse_claude_plugin
 from ai_config.converters.emitters import EmitResult, get_emitter
 from ai_config.converters.ir import InstallScope, PluginIR, Severity, TargetTool
 from ai_config.converters.report import ConversionReport
-from ai_config.pi_ownership import PiDesiredFile, apply_pi_reconciliation, load_pi_ownership
+from ai_config.pi_ownership import (
+    PiDesiredFile,
+    apply_pi_reconciliation,
+    load_pi_ownership,
+    standalone_pi_source_identity,
+)
 
 
-def _standalone_pi_retained_sources(
-    root: Path, source_plugin: str, desired: list[PiDesiredFile]
-) -> set[str]:
-    """Keep other standalone projections while preventing ownership takeover."""
+def _standalone_pi_retained_sources(root: Path, source_plugin: str) -> set[str]:
+    """Keep other standalone projections while the core reconciler checks collisions."""
     previous = load_pi_ownership(root)
-    for item in desired:
-        owner = previous.get(item.relative_path)
-        if owner is not None and owner.source_plugin != item.source_plugin:
-            raise ValueError(
-                f"Pi output collision at {root / item.relative_path}; it is owned by "
-                f"'{owner.source_plugin}', not '{item.source_plugin}'"
-            )
     return {entry.source_plugin for entry in previous.values()} - {source_plugin}
 
 
@@ -75,6 +71,7 @@ def convert_plugin(
     for target in targets:
         report = _convert_to_target(
             ir=ir,
+            source_path=plugin_path,
             target=target,
             output_dir=output_dir,
             scope=scope,
@@ -88,6 +85,7 @@ def convert_plugin(
 
 def _convert_to_target(
     ir: PluginIR,
+    source_path: Path,
     target: TargetTool,
     output_dir: Path | None,
     scope: InstallScope,
@@ -146,18 +144,17 @@ def _convert_to_target(
     # standalone conversion remove only this plugin's stale files while retaining
     # projections from other plugins at the same root.
     if output_dir and target == TargetTool.PI:
+        source_plugin = standalone_pi_source_identity(source_path, ir.identity.plugin_id)
         desired = [
             PiDesiredFile(
-                ir.identity.plugin_id,
+                source_plugin,
                 file.path,
                 file.content.encode("utf-8") if isinstance(file.content, str) else file.content,
                 file.executable,
             )
             for file in result.files
         ]
-        retained_sources = _standalone_pi_retained_sources(
-            output_dir, ir.identity.plugin_id, desired
-        )
+        retained_sources = _standalone_pi_retained_sources(output_dir, source_plugin)
         actions = apply_pi_reconciliation(
             output_dir, desired, dry_run=dry_run, retained_sources=retained_sources
         )
@@ -227,16 +224,17 @@ def convert_plugin_simple(
     if output_dir:
         if target == TargetTool.PI:
             root = Path(output_dir)
+            source_plugin = standalone_pi_source_identity(plugin_path, ir.identity.plugin_id)
             desired = [
                 PiDesiredFile(
-                    ir.identity.plugin_id,
+                    source_plugin,
                     file.path,
                     file.content.encode("utf-8") if isinstance(file.content, str) else file.content,
                     file.executable,
                 )
                 for file in result.files
             ]
-            retained_sources = _standalone_pi_retained_sources(root, ir.identity.plugin_id, desired)
+            retained_sources = _standalone_pi_retained_sources(root, source_plugin)
             apply_pi_reconciliation(root, desired, retained_sources=retained_sources)
         else:
             result.write_to(Path(output_dir))

--- a/src/ai_config/converters/convert.py
+++ b/src/ai_config/converters/convert.py
@@ -12,6 +12,22 @@ from ai_config.converters.claude_parser import parse_claude_plugin
 from ai_config.converters.emitters import EmitResult, get_emitter
 from ai_config.converters.ir import InstallScope, PluginIR, Severity, TargetTool
 from ai_config.converters.report import ConversionReport
+from ai_config.pi_ownership import PiDesiredFile, apply_pi_reconciliation, load_pi_ownership
+
+
+def _standalone_pi_retained_sources(
+    root: Path, source_plugin: str, desired: list[PiDesiredFile]
+) -> set[str]:
+    """Keep other standalone projections while preventing ownership takeover."""
+    previous = load_pi_ownership(root)
+    for item in desired:
+        owner = previous.get(item.relative_path)
+        if owner is not None and owner.source_plugin != item.source_plugin:
+            raise ValueError(
+                f"Pi output collision at {root / item.relative_path}; it is owned by "
+                f"'{owner.source_plugin}', not '{item.source_plugin}'"
+            )
+    return {entry.source_plugin for entry in previous.values()} - {source_plugin}
 
 
 def convert_plugin(
@@ -126,8 +142,34 @@ def _convert_to_target(
             lost_features=lost_features,
         )
 
-    # Write files (or preview in dry-run)
-    if output_dir:
+    # Pi output is always reconciled through its ownership ledger. This lets a
+    # standalone conversion remove only this plugin's stale files while retaining
+    # projections from other plugins at the same root.
+    if output_dir and target == TargetTool.PI:
+        desired = [
+            PiDesiredFile(
+                ir.identity.plugin_id,
+                file.path,
+                file.content.encode("utf-8") if isinstance(file.content, str) else file.content,
+                file.executable,
+            )
+            for file in result.files
+        ]
+        retained_sources = _standalone_pi_retained_sources(
+            output_dir, ir.identity.plugin_id, desired
+        )
+        actions = apply_pi_reconciliation(
+            output_dir, desired, dry_run=dry_run, retained_sources=retained_sources
+        )
+        desired_sizes = {item.relative_path: len(item.content) for item in desired}
+        for item in actions:
+            report.add_file(
+                path=output_dir / item.path,
+                action=item.action.removesuffix("_pi_output"),
+                size_bytes=desired_sizes.get(item.path, 0),
+                reason=item.reason,
+            )
+    elif output_dir:
         for f in result.files:
             full_path = output_dir / f.path
             if isinstance(f.content, bytes):
@@ -181,9 +223,23 @@ def convert_plugin_simple(
     emitter = get_emitter(target)
     result = emitter.emit(ir)
 
-    # Write if output specified
+    # Pi writes must establish ownership, even through this convenience API.
     if output_dir:
-        result.write_to(Path(output_dir))
+        if target == TargetTool.PI:
+            root = Path(output_dir)
+            desired = [
+                PiDesiredFile(
+                    ir.identity.plugin_id,
+                    file.path,
+                    file.content.encode("utf-8") if isinstance(file.content, str) else file.content,
+                    file.executable,
+                )
+                for file in result.files
+            ]
+            retained_sources = _standalone_pi_retained_sources(root, ir.identity.plugin_id, desired)
+            apply_pi_reconciliation(root, desired, retained_sources=retained_sources)
+        else:
+            result.write_to(Path(output_dir))
 
     return result
 

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -21,6 +21,8 @@ from ai_config.codex_lifecycle import (
 from ai_config.converters import InstallScope, TargetTool, convert_plugin
 from ai_config.converters.claude_parser import normalize_portable_name, parse_claude_plugin
 from ai_config.converters.codex_package import CodexPackageSpec, codex_package_spec
+from ai_config.converters.emitters import PiEmitter
+from ai_config.pi_ownership import PiDesiredFile, apply_pi_reconciliation, load_pi_ownership
 from ai_config.types import (
     AIConfig,
     ClaudeTargetConfig,
@@ -34,7 +36,7 @@ from ai_config.types import (
     TargetConfig,
 )
 
-_CONVERSION_CACHE_VERSION = 6
+_CONVERSION_CACHE_VERSION = 7
 
 
 @dataclass(frozen=True)
@@ -82,6 +84,13 @@ def _load_conversion_cache() -> dict:
     ):
         raise ValueError(
             f"Invalid conversion cache Codex output roots at {cache_path}; clear it and retry"
+        )
+    pi_dirs = raw.get("pi_output_dirs", [])
+    if not isinstance(pi_dirs, list) or any(
+        not isinstance(item, str) or not item for item in pi_dirs
+    ):
+        raise ValueError(
+            f"Invalid conversion cache Pi output roots at {cache_path}; clear the cache and retry"
         )
     return raw
 
@@ -467,6 +476,15 @@ def _owned_codex_output_dirs(
     return owned_roots
 
 
+def _pi_root_has_ownership(root: Path) -> bool:
+    """Return whether a root has a readable ai-config Pi ledger."""
+    try:
+        return bool(load_pi_ownership(root))
+    except ValueError:
+        # The reconciliation call surfaces malformed state as a hard error.
+        return True
+
+
 def _sync_lifecycle_actions(actions: Iterable[CodexLifecycleAction]) -> list[SyncAction]:
     return [
         SyncAction(action=action.action, target=action.target, reason=action.reason)
@@ -528,6 +546,12 @@ def _sync_conversions(
     ):
         return [], [], ["Invalid cached Codex output roots; clear the cache and retry"]
     cache["codex_output_dirs"] = tracked_output_dirs
+    tracked_pi_output_dirs = cache.get("pi_output_dirs", [])
+    if not isinstance(tracked_pi_output_dirs, list) or any(
+        not isinstance(tracked, str) or not tracked for tracked in tracked_pi_output_dirs
+    ):
+        return [], [], ["Invalid cached Pi output roots; clear the cache and retry"]
+    cache["pi_output_dirs"] = tracked_pi_output_dirs
     cache_dirty = False
 
     conversion = config.conversion
@@ -545,7 +569,12 @@ def _sync_conversions(
         scope = InstallScope.PROJECT
         signature = ""
     codex_enabled = TargetTool.CODEX in targets
+    pi_enabled = TargetTool.PI in targets
     resolved_output_dir = str(output_dir.resolve())
+    if pi_enabled and resolved_output_dir not in tracked_pi_output_dirs:
+        tracked_pi_output_dirs.append(resolved_output_dir)
+        tracked_pi_output_dirs.sort()
+        cache_dirty = True
     if codex_enabled and resolved_output_dir not in tracked_output_dirs:
         tracked_output_dirs.append(resolved_output_dir)
         tracked_output_dirs.sort()
@@ -567,6 +596,14 @@ def _sync_conversions(
         root
         for root in prior_output_dirs
         if not codex_enabled or root.resolve() != output_dir.resolve()
+    ]
+    prior_pi_output_dirs = [
+        Path(item).expanduser().resolve()
+        for item in tracked_pi_output_dirs
+        if _pi_root_has_ownership(Path(item).expanduser().resolve())
+    ]
+    retiring_pi_output_dirs = [
+        root for root in prior_pi_output_dirs if not pi_enabled or root != output_dir.resolve()
     ]
 
     installed_by_id: dict[str, claude.InstalledPlugin] = {}
@@ -671,6 +708,20 @@ def _sync_conversions(
             errors.append(str(error))
             return [], [], errors
 
+    # Pi is reconciled as one owned output set, rather than plugin-by-plugin writes.
+    pi_desired: list[PiDesiredFile] = []
+    if pi_enabled:
+        for candidate in candidates:
+            ir = parse_claude_plugin(candidate.plugin_path)
+            emitted = PiEmitter(scope).emit(ir)
+            for file in emitted.files:
+                content = (
+                    file.content.encode("utf-8") if isinstance(file.content, str) else file.content
+                )
+                pi_desired.append(
+                    PiDesiredFile(candidate.config_id, file.path, content, file.executable)
+                )
+
     candidates_to_convert: list[tuple[_ConversionCandidate, str | None]] = []
     for candidate in candidates:
         plugin_hash = _compute_plugin_hash(candidate.plugin_path)
@@ -690,12 +741,15 @@ def _sync_conversions(
         if not cache_valid:
             candidates_to_convert.append((candidate, plugin_hash))
 
+    # Pi has its own ownership-aware write path; other targets retain existing behavior.
+    non_pi_targets = [target for target in targets if target != TargetTool.PI]
+
     # Validate every emitter result in memory before lifecycle cleanup or generated writes.
     for candidate, _plugin_hash in candidates_to_convert:
         try:
             reports = convert_plugin(
                 plugin_path=candidate.plugin_path,
-                targets=targets,
+                targets=non_pi_targets,
                 output_dir=output_dir,
                 scope=scope,
                 dry_run=True,
@@ -716,6 +770,13 @@ def _sync_conversions(
     preflight_actions: list[SyncAction] = []
     target_removed_reason = "Codex conversion target is disabled or removed"
     try:
+        pi_plan_roots = [(output_dir, pi_desired)] if pi_enabled else []
+        pi_plan_roots.extend((root, []) for root in retiring_pi_output_dirs)
+        for pi_root, desired in pi_plan_roots:
+            preflight_actions.extend(
+                SyncAction(action=action.action, target=str(action.path), reason=action.reason)
+                for action in apply_pi_reconciliation(pi_root, desired, dry_run=True)
+            )
         for retiring_root in retiring_output_dirs:
             planned = sync_codex_packages(
                 [],
@@ -758,6 +819,23 @@ def _sync_conversions(
     if dry_run:
         return preflight_actions, [], []
 
+    # Do not checkpoint ownership until each root's entire filesystem plan succeeds.
+    for pi_root, desired in ([(output_dir, pi_desired)] if pi_enabled else []) + [
+        (root, []) for root in retiring_pi_output_dirs
+    ]:
+        try:
+            completed_pi = apply_pi_reconciliation(pi_root, desired)
+            actions.extend(
+                SyncAction(action=item.action, target=str(item.path), reason=item.reason)
+                for item in completed_pi
+            )
+        except (OSError, ValueError) as error:
+            return actions, failed_actions, [str(error)]
+    retained_pi_roots = {str(output_dir.resolve())} if pi_enabled else set()
+    if tracked_pi_output_dirs != sorted(retained_pi_roots):
+        tracked_pi_output_dirs[:] = sorted(retained_pi_roots)
+        cache_dirty = True
+
     for retiring_root in retiring_output_dirs:
         completed, failed, lifecycle_errors = _apply_codex_lifecycle(
             [],
@@ -781,7 +859,7 @@ def _sync_conversions(
         try:
             reports = convert_plugin(
                 plugin_path=candidate.plugin_path,
-                targets=targets,
+                targets=non_pi_targets,
                 output_dir=output_dir,
                 scope=scope,
                 dry_run=False,

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -812,7 +812,11 @@ def _sync_conversions(
             preflight_actions.extend(
                 SyncAction(action=action.action, target=str(action.path), reason=action.reason)
                 for action in apply_pi_reconciliation(
-                    pi_root, desired, dry_run=True, retained_sources=retained_sources
+                    pi_root,
+                    desired,
+                    dry_run=True,
+                    retained_sources=retained_sources,
+                    ownership_domain="sync",
                 )
             )
         for retiring_root in retiring_output_dirs:
@@ -863,7 +867,10 @@ def _sync_conversions(
     ) + [(root, [], set()) for root in retiring_pi_output_dirs]:
         try:
             completed_pi = apply_pi_reconciliation(
-                pi_root, desired, retained_sources=retained_sources
+                pi_root,
+                desired,
+                retained_sources=retained_sources,
+                ownership_domain="sync",
             )
             actions.extend(
                 SyncAction(action=item.action, target=str(item.path), reason=item.reason)
@@ -873,9 +880,11 @@ def _sync_conversions(
             return actions, failed_actions, [str(error)]
     # Keep a root in the cache only while it still has owned output. An enabled
     # Pi target with no configured (or no emitting) plugins has converged too.
-    retained_pi_roots = (
-        {str(output_dir.resolve())} if pi_enabled and _pi_root_has_ownership(output_dir) else set()
-    )
+    retained_pi_roots = {
+        str(root.resolve())
+        for root in ([output_dir] if pi_enabled else []) + prior_pi_output_dirs
+        if _pi_root_has_ownership(root)
+    }
     if tracked_pi_output_dirs != sorted(retained_pi_roots):
         tracked_pi_output_dirs[:] = sorted(retained_pi_roots)
         cache_dirty = True

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -618,6 +618,7 @@ def _sync_conversions(
     removal_reasons: dict[str, str] = {}
     candidates: list[_ConversionCandidate] = []
     codex_sources: dict[str, str] = {}
+    unavailable_pi_sources: set[str] = set()
     has_blocking_errors = False
 
     if conversion_active:
@@ -634,6 +635,8 @@ def _sync_conversions(
             if plugin_path is None:
                 if codex_enabled:
                     retained_codex_ids.add(configured_codex_id)
+                if pi_enabled:
+                    unavailable_pi_sources.add(plugin_config.id)
                 install_path = (
                     installed.install_path
                     if installed is not None and installed.install_path
@@ -641,7 +644,7 @@ def _sync_conversions(
                 )
                 errors.append(
                     f"Conversion source for {plugin_config.id} is temporarily unavailable "
-                    f"(installPath={install_path}); prior owned Codex state was retained"
+                    f"(installPath={install_path}); prior owned conversion state was retained"
                 )
                 continue
 
@@ -709,11 +712,42 @@ def _sync_conversions(
             return [], [], errors
 
     # Pi is reconciled as one owned output set, rather than plugin-by-plugin writes.
+    # Its parser/emitter diagnostics must be fatal before any lifecycle plan can mutate output.
     pi_desired: list[PiDesiredFile] = []
+    pi_diagnostic_errors = False
     if pi_enabled:
         for candidate in candidates:
-            ir = parse_claude_plugin(candidate.plugin_path)
-            emitted = PiEmitter(scope).emit(ir)
+            try:
+                ir = parse_claude_plugin(candidate.plugin_path)
+                parse_errors = [
+                    diagnostic.message
+                    for diagnostic in ir.diagnostics
+                    if diagnostic.severity.value == "error"
+                ]
+                if parse_errors:
+                    pi_diagnostic_errors = True
+                    errors.extend(
+                        f"Pi conversion failed for {candidate.config_id}: {message}"
+                        for message in parse_errors
+                    )
+                    continue
+                emitted = PiEmitter(scope).emit(ir)
+                emit_errors = [
+                    diagnostic.message
+                    for diagnostic in emitted.diagnostics
+                    if diagnostic.severity.value == "error"
+                ]
+                if emit_errors:
+                    pi_diagnostic_errors = True
+                    errors.extend(
+                        f"Pi conversion failed for {candidate.config_id}: {message}"
+                        for message in emit_errors
+                    )
+                    continue
+            except (OSError, ValueError) as error:
+                pi_diagnostic_errors = True
+                errors.append(f"Pi conversion failed for {candidate.config_id}: {error}")
+                continue
             for file in emitted.files:
                 content = (
                     file.content.encode("utf-8") if isinstance(file.content, str) else file.content
@@ -721,6 +755,8 @@ def _sync_conversions(
                 pi_desired.append(
                     PiDesiredFile(candidate.config_id, file.path, content, file.executable)
                 )
+        if pi_diagnostic_errors:
+            return [], [], errors
 
     candidates_to_convert: list[tuple[_ConversionCandidate, str | None]] = []
     for candidate in candidates:
@@ -770,12 +806,14 @@ def _sync_conversions(
     preflight_actions: list[SyncAction] = []
     target_removed_reason = "Codex conversion target is disabled or removed"
     try:
-        pi_plan_roots = [(output_dir, pi_desired)] if pi_enabled else []
-        pi_plan_roots.extend((root, []) for root in retiring_pi_output_dirs)
-        for pi_root, desired in pi_plan_roots:
+        pi_plan_roots = [(output_dir, pi_desired, unavailable_pi_sources)] if pi_enabled else []
+        pi_plan_roots.extend((root, [], set()) for root in retiring_pi_output_dirs)
+        for pi_root, desired, retained_sources in pi_plan_roots:
             preflight_actions.extend(
                 SyncAction(action=action.action, target=str(action.path), reason=action.reason)
-                for action in apply_pi_reconciliation(pi_root, desired, dry_run=True)
+                for action in apply_pi_reconciliation(
+                    pi_root, desired, dry_run=True, retained_sources=retained_sources
+                )
             )
         for retiring_root in retiring_output_dirs:
             planned = sync_codex_packages(
@@ -820,11 +858,13 @@ def _sync_conversions(
         return preflight_actions, [], []
 
     # Do not checkpoint ownership until each root's entire filesystem plan succeeds.
-    for pi_root, desired in ([(output_dir, pi_desired)] if pi_enabled else []) + [
-        (root, []) for root in retiring_pi_output_dirs
-    ]:
+    for pi_root, desired, retained_sources in (
+        [(output_dir, pi_desired, unavailable_pi_sources)] if pi_enabled else []
+    ) + [(root, [], set()) for root in retiring_pi_output_dirs]:
         try:
-            completed_pi = apply_pi_reconciliation(pi_root, desired)
+            completed_pi = apply_pi_reconciliation(
+                pi_root, desired, retained_sources=retained_sources
+            )
             actions.extend(
                 SyncAction(action=item.action, target=str(item.path), reason=item.reason)
                 for item in completed_pi
@@ -1083,7 +1123,7 @@ def sync_discrepancies(results: dict[str, SyncResult]) -> list[str]:
         discrepancies.extend(
             f"{target_type}: {action.action} required for {action.target}: {action.reason}"
             for action in result.actions_taken
-            if action.action != "noop_codex_plugin"
+            if action.action not in {"noop_codex_plugin", "noop_pi_output"}
         )
     return discrepancies
 

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -871,7 +871,11 @@ def _sync_conversions(
             )
         except (OSError, ValueError) as error:
             return actions, failed_actions, [str(error)]
-    retained_pi_roots = {str(output_dir.resolve())} if pi_enabled else set()
+    # Keep a root in the cache only while it still has owned output. An enabled
+    # Pi target with no configured (or no emitting) plugins has converged too.
+    retained_pi_roots = (
+        {str(output_dir.resolve())} if pi_enabled and _pi_root_has_ownership(output_dir) else set()
+    )
     if tracked_pi_output_dirs != sorted(retained_pi_roots):
         tracked_pi_output_dirs[:] = sorted(retained_pi_roots)
         cache_dirty = True

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -7,12 +7,13 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from ai_config.output_safety import validated_output_path
 
 _PI_STATE = Path(".ai-config") / "pi-ownership.json"
-_VERSION = 1
+_PI_PENDING = Path(".ai-config") / "pi-ownership.pending.json"
+_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -20,6 +21,7 @@ class PiOwnedFile:
     source_plugin: str
     relative_path: Path
     digest: str
+    executable: bool = False
 
 
 @dataclass(frozen=True)
@@ -62,48 +64,182 @@ def _state_path(root: Path) -> Path:
     return validated_output_path(root, _PI_STATE)
 
 
-def load_pi_ownership(root: Path) -> dict[Path, PiOwnedFile]:
-    """Load a ledger only when it proves ownership of this exact target root."""
-    root = root.expanduser().resolve()
-    path = _state_path(root)
-    if not path.exists():
-        return {}
-    if path.is_symlink():
-        raise ValueError(f"Refusing symlinked Pi ownership state: {path}")
-    try:
-        payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError) as error:
-        raise ValueError(f"Invalid Pi ownership state at {path}: {error}") from error
-    if (
-        not isinstance(payload, dict)
-        or payload.get("version") != _VERSION
-        or payload.get("root") != str(root)
-    ):
-        raise ValueError(f"Invalid Pi ownership state at {path}; refusing ambiguous cleanup")
-    raw_files = payload.get("files")
+def _pending_path(root: Path) -> Path:
+    return validated_output_path(root, _PI_PENDING)
+
+
+def _decode_entries(
+    raw_files: object, path: Path, *, allow_v1: bool = False
+) -> dict[Path, PiOwnedFile]:
     if not isinstance(raw_files, list):
         raise ValueError(f"Invalid Pi ownership files at {path}")
     owned: dict[Path, PiOwnedFile] = {}
     for raw in raw_files:
         if not isinstance(raw, dict):
             raise ValueError(f"Invalid Pi ownership entry at {path}")
+        raw = cast(dict[str, object], raw)
         source, relative, digest = raw.get("source_plugin"), raw.get("path"), raw.get("digest")
-        if not all(isinstance(value, str) and value for value in (source, relative, digest)):
+        executable = raw.get("executable", False if allow_v1 else None)
+        if not all(
+            isinstance(value, str) and value for value in (source, relative, digest)
+        ) or not isinstance(executable, bool):
+            raise ValueError(f"Incomplete Pi ownership entry at {path}")
+        source, relative, digest, executable = (
+            cast(str, source),
+            cast(str, relative),
+            cast(str, digest),
+            executable,
+        )
+        if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
             raise ValueError(f"Incomplete Pi ownership entry at {path}")
         relative_path = _safe_relative(Path(relative))
-        if relative_path in owned or len(digest) != 64:
+        if relative_path in owned:
             raise ValueError(f"Ambiguous Pi ownership entry at {path}")
-        validated_output_path(root, relative_path)
-        owned[relative_path] = PiOwnedFile(source, relative_path, digest)
+        owned[relative_path] = PiOwnedFile(source, relative_path, digest, executable)
     return owned
 
 
+def _load_json(path: Path, label: str) -> dict[str, object] | None:
+    if path.is_symlink():
+        raise ValueError(f"Refusing symlinked Pi {label}: {path}")
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Invalid Pi {label} at {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError(f"Invalid Pi {label} at {path}")
+    return payload
+
+
+def load_pi_ownership(root: Path) -> dict[Path, PiOwnedFile]:
+    """Load a ledger only when it proves ownership of this exact target root."""
+    root = root.expanduser().resolve()
+    path = _state_path(root)
+    payload = _load_json(path, "ownership state")
+    if payload is None:
+        return {}
+    version = payload.get("version")
+    if version not in {1, _VERSION} or payload.get("root") != str(root):
+        raise ValueError(f"Invalid Pi ownership state at {path}; refusing ambiguous cleanup")
+    return _decode_entries(payload.get("files"), path, allow_v1=version == 1)
+
+
+def _entry_payload(entries: dict[Path, PiOwnedFile]) -> list[dict[str, object]]:
+    return [
+        {
+            "source_plugin": entry.source_plugin,
+            "path": entry.relative_path.as_posix(),
+            "digest": entry.digest,
+            "executable": entry.executable,
+        }
+        for _, entry in sorted(entries.items(), key=lambda pair: pair[0].as_posix())
+    ]
+
+
+def _atomic_write(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    if temporary.exists() or temporary.is_symlink():
+        temporary.unlink()
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    os.replace(temporary, path)
+
+
+def _write_state(root: Path, entries: dict[Path, PiOwnedFile]) -> None:
+    _atomic_write(
+        _state_path(root),
+        {
+            "version": _VERSION,
+            "root": str(root.expanduser().resolve()),
+            "files": _entry_payload(entries),
+        },
+    )
+
+
+def _write_pending(root: Path, actions: list[PiAction], entries: dict[Path, PiOwnedFile]) -> None:
+    _atomic_write(
+        _pending_path(root),
+        {
+            "version": _VERSION,
+            "root": str(root),
+            "files": _entry_payload(entries),
+            "actions": [
+                {"action": action.action, "path": action.path.as_posix(), "reason": action.reason}
+                for action in actions
+            ],
+        },
+    )
+
+
+def _load_pending(root: Path) -> tuple[list[PiAction], dict[Path, PiOwnedFile]] | None:
+    path = _pending_path(root)
+    payload = _load_json(path, "ownership pending transaction")
+    if payload is None:
+        return None
+    if payload.get("version") != _VERSION or payload.get("root") != str(root):
+        raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+    entries = _decode_entries(payload.get("files"), path)
+    raw_actions = payload.get("actions")
+    valid_actions = {
+        "create_pi_output",
+        "update_pi_output",
+        "remove_pi_output",
+        "noop_pi_output",
+        "preserve_pi_output",
+    }
+    if not isinstance(raw_actions, list):
+        raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+    actions: list[PiAction] = []
+    seen: set[Path] = set()
+    for raw in raw_actions:
+        if not isinstance(raw, dict):
+            raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+        raw = cast(dict[str, object], raw)
+        action, relative, reason = raw.get("action"), raw.get("path"), raw.get("reason")
+        if (
+            not isinstance(action, str)
+            or action not in valid_actions
+            or not isinstance(relative, str)
+            or not isinstance(reason, str)
+        ):
+            raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+        safe = _safe_relative(Path(relative))
+        validated_output_path(root, safe)
+        if safe in seen:
+            raise ValueError(f"Ambiguous Pi ownership pending transaction at {path}")
+        seen.add(safe)
+        actions.append(
+            PiAction(
+                cast(
+                    Literal[
+                        "create_pi_output",
+                        "update_pi_output",
+                        "remove_pi_output",
+                        "noop_pi_output",
+                        "preserve_pi_output",
+                    ],
+                    action,
+                ),
+                safe,
+                reason,
+            )
+        )
+    return actions, entries
+
+
+def _is_executable(path: Path) -> bool:
+    return bool(path.stat().st_mode & 0o111)
+
+
 def plan_pi_reconciliation(
-    root: Path, desired: list[PiDesiredFile]
+    root: Path, desired: list[PiDesiredFile], *, retained_sources: set[str] | None = None
 ) -> tuple[list[PiAction], dict[Path, PiOwnedFile]]:
     """Plan Pi changes without modifying disk; never adopt unowned output."""
     root = root.expanduser().resolve()
     previous = load_pi_ownership(root)
+    retained_sources = retained_sources or set()
     desired_by_path: dict[Path, PiDesiredFile] = {}
     for item in desired:
         relative = _safe_relative(item.relative_path)
@@ -116,7 +252,7 @@ def plan_pi_reconciliation(
     for relative, item in sorted(desired_by_path.items(), key=lambda pair: pair[0].as_posix()):
         path = validated_output_path(root, relative)
         old = previous.get(relative)
-        if path.exists() and path.is_symlink():
+        if path.is_symlink():
             raise ValueError(f"Refusing symlinked Pi output: {path}")
         if old is None and path.exists():
             raise ValueError(
@@ -128,9 +264,16 @@ def plan_pi_reconciliation(
                 PiAction("preserve_pi_output", relative, "Locally modified owned output")
             )
             next_state[relative] = old
-        elif old is not None and path.exists() and old.digest == item.digest:
+        elif (
+            old is not None
+            and path.exists()
+            and old.digest == item.digest
+            and _is_executable(path) == item.executable
+        ):
             actions.append(PiAction("noop_pi_output", relative, "Owned output already matches"))
-            next_state[relative] = PiOwnedFile(item.source_plugin, relative, item.digest)
+            next_state[relative] = PiOwnedFile(
+                item.source_plugin, relative, item.digest, item.executable
+            )
         else:
             actions.append(
                 PiAction(
@@ -139,12 +282,22 @@ def plan_pi_reconciliation(
                     "Generated Pi output changed",
                 )
             )
-            next_state[relative] = PiOwnedFile(item.source_plugin, relative, item.digest)
+            next_state[relative] = PiOwnedFile(
+                item.source_plugin, relative, item.digest, item.executable
+            )
     for relative, old in sorted(previous.items(), key=lambda pair: pair[0].as_posix()):
         if relative in desired_by_path:
             continue
+        if old.source_plugin in retained_sources:
+            actions.append(
+                PiAction("preserve_pi_output", relative, "Pi source is temporarily unavailable")
+            )
+            next_state[relative] = old
+            continue
         path = validated_output_path(root, relative)
-        if path.exists() and (path.is_symlink() or digest_content(path.read_bytes()) != old.digest):
+        if path.is_symlink():
+            raise ValueError(f"Refusing symlinked Pi output: {path}")
+        if path.exists() and digest_content(path.read_bytes()) != old.digest:
             actions.append(
                 PiAction("preserve_pi_output", relative, "Locally modified owned output")
             )
@@ -156,37 +309,13 @@ def plan_pi_reconciliation(
     return actions, next_state
 
 
-def _write_state(root: Path, entries: dict[Path, PiOwnedFile]) -> None:
-    path = _state_path(root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "version": _VERSION,
-        "root": str(root.expanduser().resolve()),
-        "files": [
-            {
-                "source_plugin": entry.source_plugin,
-                "path": entry.relative_path.as_posix(),
-                "digest": entry.digest,
-            }
-            for _, entry in sorted(entries.items(), key=lambda pair: pair[0].as_posix())
-        ],
-    }
-    temporary = path.with_suffix(".tmp")
-    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    os.replace(temporary, path)
-
-
-def apply_pi_reconciliation(
-    root: Path, desired: list[PiDesiredFile], *, dry_run: bool = False
-) -> list[PiAction]:
-    """Reconcile and checkpoint only after all planned filesystem mutations succeed."""
-    root = root.expanduser().resolve()
-    actions, next_state = plan_pi_reconciliation(root, desired)
-    if dry_run:
-        return actions
-    desired_by_path = {item.relative_path: item for item in desired}
+def _apply_actions(
+    root: Path, actions: list[PiAction], desired_by_path: dict[Path, PiDesiredFile]
+) -> None:
     for action in actions:
         path = validated_output_path(root, action.path)
+        if path.is_symlink():
+            raise ValueError(f"Refusing symlinked Pi output: {path}")
         if action.action in {"create_pi_output", "update_pi_output"}:
             item = desired_by_path[action.path]
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -194,10 +323,57 @@ def apply_pi_reconciliation(
             if temporary.exists() or temporary.is_symlink():
                 temporary.unlink()
             temporary.write_bytes(item.content)
-            if item.executable:
-                temporary.chmod(temporary.stat().st_mode | 0o111)
+            temporary.chmod(0o755 if item.executable else 0o644)
             os.replace(temporary, path)
         elif action.action == "remove_pi_output":
             path.unlink(missing_ok=True)
+
+
+def _recover_pending(
+    root: Path, desired_by_path: dict[Path, PiDesiredFile]
+) -> list[PiAction] | None:
+    pending = _load_pending(root)
+    if pending is None:
+        return None
+    actions, next_state = pending
+    for action in actions:
+        if action.action in {"create_pi_output", "update_pi_output", "noop_pi_output"}:
+            item = desired_by_path.get(action.path)
+            entry = next_state.get(action.path)
+            if (
+                item is None
+                or entry is None
+                or (item.source_plugin, item.digest, item.executable)
+                != (entry.source_plugin, entry.digest, entry.executable)
+            ):
+                raise ValueError(
+                    "Pending Pi ownership transaction does not match current desired output; refusing unsafe recovery"
+                )
+    _apply_actions(root, actions, desired_by_path)
     _write_state(root, next_state)
+    _pending_path(root).unlink()
+    return actions
+
+
+def apply_pi_reconciliation(
+    root: Path,
+    desired: list[PiDesiredFile],
+    *,
+    dry_run: bool = False,
+    retained_sources: set[str] | None = None,
+) -> list[PiAction]:
+    """Reconcile Pi output with a durable retryable transaction journal."""
+    root = root.expanduser().resolve()
+    desired_by_path = {item.relative_path: item for item in desired}
+    if not dry_run:
+        recovered = _recover_pending(root, desired_by_path)
+        if recovered is not None:
+            return recovered
+    actions, next_state = plan_pi_reconciliation(root, desired, retained_sources=retained_sources)
+    if dry_run:
+        return actions
+    _write_pending(root, actions, next_state)
+    _apply_actions(root, actions, desired_by_path)
+    _write_state(root, next_state)
+    _pending_path(root).unlink()
     return actions

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -15,7 +15,7 @@ from ai_config.output_safety import validated_output_path
 
 _PI_STATE = Path(".ai-config") / "pi-ownership.json"
 _PI_PENDING = Path(".ai-config") / "pi-ownership.pending.json"
-_VERSION = 3
+_VERSION = 4
 PiOwnershipDomain = Literal["standalone", "sync"]
 _STANDALONE_SOURCE = re.compile(r"standalone:([^:\s]+):([0-9a-f]{64})$")
 
@@ -51,6 +51,12 @@ class PiAction:
     ]
     path: Path
     reason: str
+
+
+@dataclass(frozen=True)
+class _OwnershipState:
+    domain: PiOwnershipDomain
+    entries: dict[Path, PiOwnedFile]
 
 
 @dataclass(frozen=True)
@@ -91,26 +97,25 @@ def pi_ownership_domain(source_plugin: str) -> PiOwnershipDomain:
 
 
 def _validate_ownership_domain(
-    entries: dict[Path, PiOwnedFile],
+    state: _OwnershipState | None,
     desired: dict[Path, PiDesiredFile],
     requested_domain: PiOwnershipDomain | None,
-) -> None:
-    existing_domains = {pi_ownership_domain(entry.source_plugin) for entry in entries.values()}
+) -> PiOwnershipDomain | None:
     desired_domains = {pi_ownership_domain(item.source_plugin) for item in desired.values()}
-    if len(existing_domains) > 1 or len(desired_domains) > 1:
+    if len(desired_domains) > 1:
         raise ValueError(
             "Mixed Pi ownership domains are invalid; refusing ambiguous reconciliation"
         )
-    expected = requested_domain or next(iter(desired_domains), None)
-    if expected is not None and existing_domains and existing_domains != {expected}:
-        existing = next(iter(existing_domains))
+    expected = requested_domain or (state.domain if state else next(iter(desired_domains), None))
+    if state is not None and expected is not None and state.domain != expected:
         raise ValueError(
-            f"Pi output ownership domain conflict: this root is {existing}-managed, not "
+            f"Pi output ownership domain conflict: this root is {state.domain}-managed, not "
             f"{expected}-managed. Use a separate root or remove/reconcile the standalone "
             "projection deliberately before retrying."
         )
     if requested_domain is not None and desired_domains and desired_domains != {requested_domain}:
         raise ValueError("Pi desired output ownership domain does not match reconciliation mode")
+    return expected
 
 
 def _safe_relative(path: Path) -> Path:
@@ -173,18 +178,41 @@ def _load_json(path: Path, label: str) -> dict[str, object] | None:
     return payload
 
 
-def load_pi_ownership(root: Path) -> dict[Path, PiOwnedFile]:
-    root = root.expanduser().resolve()
+def _unsupported_schema(path: Path, label: str) -> ValueError:
+    return ValueError(
+        f"Unsupported Pi {label} schema at {path}; automatic cleanup is refused and "
+        "historical output remains outside ownership (see issue #22). Rerun only after "
+        "deliberate cleanup."
+    )
+
+
+def _decode_domain(raw: object, path: Path, label: str) -> PiOwnershipDomain:
+    if raw not in {"sync", "standalone"}:
+        raise ValueError(f"Invalid Pi {label} domain at {path}; refusing ambiguous cleanup")
+    return cast(PiOwnershipDomain, raw)
+
+
+def _load_state(root: Path) -> _OwnershipState | None:
     path = _state_path(root)
     payload = _load_json(path, "ownership state")
     if payload is None:
-        return {}
-    version = payload.get("version")
-    if version not in {1, 2, _VERSION} or payload.get("root") != str(root):
+        return None
+    if payload.get("version") != _VERSION:
+        raise _unsupported_schema(path, "ownership state")
+    if payload.get("root") != str(root):
         raise ValueError(f"Invalid Pi ownership state at {path}; refusing ambiguous cleanup")
-    # Version 1 predates executable-mode ownership. Later schemas must carry it
-    # explicitly so malformed state never makes cleanup decisions for us.
-    return _decode_entries(payload.get("files"), path, root, allow_v1=version == 1)
+    domain = _decode_domain(payload.get("domain"), path, "ownership state")
+    entries = _decode_entries(payload.get("files"), path, root)
+    if any(pi_ownership_domain(entry.source_plugin) != domain for entry in entries.values()):
+        raise ValueError(f"Pi ownership state domain does not match entry identity at {path}")
+    return _OwnershipState(domain, entries)
+
+
+def load_pi_ownership(root: Path) -> dict[Path, PiOwnedFile]:
+    """Return the public ownership-entry view after strict schema validation."""
+    root = root.expanduser().resolve()
+    state = _load_state(root)
+    return {} if state is None else state.entries
 
 
 def _entry_payload(entries: dict[Path, PiOwnedFile]) -> list[dict[str, object]]:
@@ -213,10 +241,21 @@ def _atomic_write(path: Path, payload: dict[str, object]) -> None:
         temporary.unlink(missing_ok=True)
 
 
-def _write_state(root: Path, entries: dict[Path, PiOwnedFile]) -> None:
+def _write_state(root: Path, domain: PiOwnershipDomain, entries: dict[Path, PiOwnedFile]) -> None:
+    path = _state_path(root)
+    # A first conversion with no emitted files still records its selected domain.
+    # Only an existing ledger reconciled down to no files releases the root.
+    if not entries and path.exists():
+        path.unlink()
+        return
     _atomic_write(
-        _state_path(root),
-        {"version": _VERSION, "root": str(root), "files": _entry_payload(entries)},
+        path,
+        {
+            "version": _VERSION,
+            "root": str(root),
+            "domain": domain,
+            "files": _entry_payload(entries),
+        },
     )
 
 
@@ -272,10 +311,10 @@ def _normalize_desired(root: Path, desired: list[PiDesiredFile]) -> dict[Path, P
 
 def _write_pending(
     root: Path,
+    domain: PiOwnershipDomain,
     actions: list[PiAction],
     next_state: dict[Path, PiOwnedFile],
     desired: dict[Path, PiDesiredFile],
-    previous: dict[Path, PiOwnedFile],
 ) -> None:
     records = []
     for action in actions:
@@ -305,6 +344,7 @@ def _write_pending(
         {
             "version": _VERSION,
             "root": str(root),
+            "domain": domain,
             "files": _entry_payload(next_state),
             "desired": _entry_payload(
                 {
@@ -321,6 +361,7 @@ def _load_pending(
     root: Path,
 ) -> (
     tuple[
+        PiOwnershipDomain,
         list[PiAction],
         dict[Path, PiOwnedFile],
         dict[Path, PiOwnedFile],
@@ -332,10 +373,20 @@ def _load_pending(
     payload = _load_json(path, "ownership pending transaction")
     if payload is None:
         return None
-    if payload.get("version") != _VERSION or payload.get("root") != str(root):
+    if payload.get("version") != _VERSION:
+        raise _unsupported_schema(path, "ownership pending transaction")
+    if payload.get("root") != str(root):
         raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+    domain = _decode_domain(payload.get("domain"), path, "ownership pending transaction")
     entries = _decode_entries(payload.get("files"), path, root)
     wanted = _decode_entries(payload.get("desired"), path, root)
+    if any(
+        pi_ownership_domain(entry.source_plugin) != domain
+        for entry in (*entries.values(), *wanted.values())
+    ):
+        raise ValueError(
+            f"Pi ownership pending transaction domain does not match entry identity at {path}"
+        )
     raw_actions = payload.get("actions")
     valid = {
         "create_pi_output",
@@ -391,7 +442,7 @@ def _load_pending(
         action.action == "remove_pi_output" for action in actions if action.path in wanted
     ):
         raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
-    return actions, entries, wanted, states
+    return domain, actions, entries, wanted, states
 
 
 def _is_executable(path: Path) -> bool:
@@ -406,9 +457,10 @@ def plan_pi_reconciliation(
     ownership_domain: PiOwnershipDomain | None = None,
 ) -> tuple[list[PiAction], dict[Path, PiOwnedFile]]:
     root = root.expanduser().resolve()
-    previous = load_pi_ownership(root)
+    state = _load_state(root)
+    previous = {} if state is None else state.entries
     desired_by_path = _normalize_desired(root, desired)
-    _validate_ownership_domain(previous, desired_by_path, ownership_domain)
+    _validate_ownership_domain(state, desired_by_path, ownership_domain)
     retained_sources = retained_sources or set()
     actions: list[PiAction] = []
     next_state: dict[Path, PiOwnedFile] = {}
@@ -518,12 +570,19 @@ def _apply_actions(root: Path, actions: list[PiAction], desired: dict[Path, PiDe
 
 
 def _recover_pending(
-    root: Path, desired: dict[Path, PiDesiredFile], retained_sources: set[str]
+    root: Path,
+    desired: dict[Path, PiDesiredFile],
+    retained_sources: set[str],
+    expected_domain: PiOwnershipDomain | None,
 ) -> list[PiAction] | None:
     pending = _load_pending(root)
     if pending is None:
         return None
-    actions, next_state, wanted, states = pending
+    domain, actions, next_state, wanted, states = pending
+    if expected_domain != domain:
+        raise ValueError(
+            "Pending Pi ownership transaction domain does not match reconciliation mode"
+        )
     if set(desired) != set(wanted) or any(
         (d.source_plugin, d.digest, d.executable) != (w.source_plugin, w.digest, w.executable)
         for p, d in desired.items()
@@ -556,7 +615,7 @@ def _recover_pending(
         if _disk_state(root, a.path) == states[a.path][0] and states[a.path][0] != states[a.path][1]
     ]
     _apply_actions(root, apply_now, desired)
-    _write_state(root, next_state)
+    _write_state(root, domain, next_state)
     _pending_path(root).unlink()
     return actions
 
@@ -571,16 +630,16 @@ def apply_pi_reconciliation(
 ) -> list[PiAction]:
     root = root.expanduser().resolve()
     desired_by_path = _normalize_desired(root, desired)
-    previous = load_pi_ownership(root)
-    _validate_ownership_domain(previous, desired_by_path, ownership_domain)
+    state = _load_state(root)
+    domain = _validate_ownership_domain(state, desired_by_path, ownership_domain)
     retained_sources = retained_sources or set()
     pending = _load_pending(root)
     if pending is not None:
         # Recovery validation is deliberately identical for preview and apply.
         if dry_run:
-            _recover_pending_plan(root, desired_by_path, retained_sources, pending)
-            return pending[0]
-        recovered = _recover_pending(root, desired_by_path, retained_sources)
+            _recover_pending_plan(root, desired_by_path, retained_sources, domain, pending)
+            return pending[1]
+        recovered = _recover_pending(root, desired_by_path, retained_sources, domain)
         if recovered is not None:
             return recovered
     actions, next_state = plan_pi_reconciliation(
@@ -591,9 +650,11 @@ def apply_pi_reconciliation(
     )
     if dry_run:
         return actions
-    _write_pending(root, actions, next_state, desired_by_path, previous)
+    if domain is None:
+        return actions
+    _write_pending(root, domain, actions, next_state, desired_by_path)
     _apply_actions(root, actions, desired_by_path)
-    _write_state(root, next_state)
+    _write_state(root, domain, next_state)
     _pending_path(root).unlink()
     return actions
 
@@ -602,14 +663,20 @@ def _recover_pending_plan(
     root: Path,
     desired: dict[Path, PiDesiredFile],
     retained_sources: set[str],
+    expected_domain: PiOwnershipDomain | None,
     pending: tuple[
+        PiOwnershipDomain,
         list[PiAction],
         dict[Path, PiOwnedFile],
         dict[Path, PiOwnedFile],
         dict[Path, tuple[_DiskState, _DiskState]],
     ],
 ) -> None:
-    actions, _next, wanted, states = pending
+    domain, actions, _next, wanted, states = pending
+    if expected_domain != domain:
+        raise ValueError(
+            "Pending Pi ownership transaction domain does not match reconciliation mode"
+        )
     if set(desired) != set(wanted) or any(
         (d.source_plugin, d.digest, d.executable)
         != (wanted[p].source_plugin, wanted[p].digest, wanted[p].executable)

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -153,10 +153,9 @@ def _atomic_write(path: Path, payload: dict[str, object]) -> None:
             json.dump(payload, handle, indent=2, sort_keys=True)
             handle.write("\n")
         os.replace(temporary, path)
-    except BaseException:
+    finally:
         # Only this process-created name is ever cleaned up.
         temporary.unlink(missing_ok=True)
-        raise
 
 
 def _write_state(root: Path, entries: dict[Path, PiOwnedFile]) -> None:
@@ -425,9 +424,9 @@ def _apply_actions(root: Path, actions: list[PiAction], desired: dict[Path, PiDe
                     handle.write(item.content)
                 temporary.chmod(0o755 if item.executable else 0o644)
                 os.replace(temporary, path)
-            except BaseException:
+            finally:
+                # Only this process-created name is ever cleaned up.
                 temporary.unlink(missing_ok=True)
-                raise
         elif action.action == "remove_pi_output":
             # State validation before this call proves this is the exact old owned file.
             path.unlink(missing_ok=True)

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +16,8 @@ from ai_config.output_safety import validated_output_path
 _PI_STATE = Path(".ai-config") / "pi-ownership.json"
 _PI_PENDING = Path(".ai-config") / "pi-ownership.pending.json"
 _VERSION = 3
+PiOwnershipDomain = Literal["standalone", "sync"]
+_STANDALONE_SOURCE = re.compile(r"standalone:([^:\s]+):([0-9a-f]{64})$")
 
 
 @dataclass(frozen=True)
@@ -63,9 +66,51 @@ def digest_content(content: bytes | str) -> str:
 
 def standalone_pi_source_identity(plugin_path: Path, plugin_id: str) -> str:
     """Return a path-stable ledger owner for one standalone plugin source."""
+    if not plugin_id or any(char.isspace() or char == ":" for char in plugin_id):
+        raise ValueError(f"Invalid standalone Pi source plugin identity: {plugin_id!r}")
     resolved_path = plugin_path.expanduser().resolve()
     path_digest = hashlib.sha256(str(resolved_path).encode()).hexdigest()
     return f"standalone:{plugin_id}:{path_digest}"
+
+
+def pi_ownership_domain(source_plugin: str) -> PiOwnershipDomain:
+    """Classify and strictly validate one Pi ledger source identity."""
+    if _STANDALONE_SOURCE.fullmatch(source_plugin):
+        return "standalone"
+    if source_plugin.startswith("standalone:"):
+        raise ValueError(f"Invalid standalone Pi ownership identity: {source_plugin!r}")
+    if (
+        not source_plugin
+        or source_plugin.count("@") > 1
+        or source_plugin.startswith("@")
+        or source_plugin.endswith("@")
+        or any(char.isspace() or char == ":" for char in source_plugin)
+    ):
+        raise ValueError(f"Invalid sync Pi ownership identity: {source_plugin!r}")
+    return "sync"
+
+
+def _validate_ownership_domain(
+    entries: dict[Path, PiOwnedFile],
+    desired: dict[Path, PiDesiredFile],
+    requested_domain: PiOwnershipDomain | None,
+) -> None:
+    existing_domains = {pi_ownership_domain(entry.source_plugin) for entry in entries.values()}
+    desired_domains = {pi_ownership_domain(item.source_plugin) for item in desired.values()}
+    if len(existing_domains) > 1 or len(desired_domains) > 1:
+        raise ValueError(
+            "Mixed Pi ownership domains are invalid; refusing ambiguous reconciliation"
+        )
+    expected = requested_domain or next(iter(desired_domains), None)
+    if expected is not None and existing_domains and existing_domains != {expected}:
+        existing = next(iter(existing_domains))
+        raise ValueError(
+            f"Pi output ownership domain conflict: this root is {existing}-managed, not "
+            f"{expected}-managed. Use a separate root or remove/reconcile the standalone "
+            "projection deliberately before retrying."
+        )
+    if requested_domain is not None and desired_domains and desired_domains != {requested_domain}:
+        raise ValueError("Pi desired output ownership domain does not match reconciliation mode")
 
 
 def _safe_relative(path: Path) -> Path:
@@ -99,6 +144,7 @@ def _decode_entries(
             isinstance(value, str) and value for value in (source, relative, digest)
         ) or not isinstance(executable, bool):
             raise ValueError(f"Incomplete Pi ownership entry at {path}")
+        pi_ownership_domain(cast(str, source))
         if len(cast(str, digest)) != 64 or any(
             char not in "0123456789abcdef" for char in cast(str, digest)
         ):
@@ -353,11 +399,16 @@ def _is_executable(path: Path) -> bool:
 
 
 def plan_pi_reconciliation(
-    root: Path, desired: list[PiDesiredFile], *, retained_sources: set[str] | None = None
+    root: Path,
+    desired: list[PiDesiredFile],
+    *,
+    retained_sources: set[str] | None = None,
+    ownership_domain: PiOwnershipDomain | None = None,
 ) -> tuple[list[PiAction], dict[Path, PiOwnedFile]]:
     root = root.expanduser().resolve()
     previous = load_pi_ownership(root)
     desired_by_path = _normalize_desired(root, desired)
+    _validate_ownership_domain(previous, desired_by_path, ownership_domain)
     retained_sources = retained_sources or set()
     actions: list[PiAction] = []
     next_state: dict[Path, PiOwnedFile] = {}
@@ -516,9 +567,12 @@ def apply_pi_reconciliation(
     *,
     dry_run: bool = False,
     retained_sources: set[str] | None = None,
+    ownership_domain: PiOwnershipDomain | None = None,
 ) -> list[PiAction]:
     root = root.expanduser().resolve()
     desired_by_path = _normalize_desired(root, desired)
+    previous = load_pi_ownership(root)
+    _validate_ownership_domain(previous, desired_by_path, ownership_domain)
     retained_sources = retained_sources or set()
     pending = _load_pending(root)
     if pending is not None:
@@ -530,11 +584,13 @@ def apply_pi_reconciliation(
         if recovered is not None:
             return recovered
     actions, next_state = plan_pi_reconciliation(
-        root, list(desired_by_path.values()), retained_sources=retained_sources
+        root,
+        list(desired_by_path.values()),
+        retained_sources=retained_sources,
+        ownership_domain=ownership_domain,
     )
     if dry_run:
         return actions
-    previous = load_pi_ownership(root)
     _write_pending(root, actions, next_state, desired_by_path, previous)
     _apply_actions(root, actions, desired_by_path)
     _write_state(root, next_state)

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -61,6 +61,13 @@ def digest_content(content: bytes | str) -> str:
     return hashlib.sha256(content.encode() if isinstance(content, str) else content).hexdigest()
 
 
+def standalone_pi_source_identity(plugin_path: Path, plugin_id: str) -> str:
+    """Return a path-stable ledger owner for one standalone plugin source."""
+    resolved_path = plugin_path.expanduser().resolve()
+    path_digest = hashlib.sha256(str(resolved_path).encode()).hexdigest()
+    return f"standalone:{plugin_id}:{path_digest}"
+
+
 def _safe_relative(path: Path) -> Path:
     # Path normalizes harmless ``.`` components; reject lexical traversal before it can escape.
     if path.is_absolute() or ".." in path.parts or not path.parts:
@@ -357,6 +364,11 @@ def plan_pi_reconciliation(
     for relative, item in sorted(desired_by_path.items(), key=lambda p: p[0].as_posix()):
         path = validated_output_path(root, relative)
         old = previous.get(relative)
+        if old is not None and old.source_plugin != item.source_plugin:
+            raise ValueError(
+                f"Pi output ownership collision at {path}; existing owner "
+                f"'{old.source_plugin}' conflicts with requested owner '{item.source_plugin}'"
+            )
         current = _disk_state(root, relative)
         if old is None and current.exists:
             raise ValueError(

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -1,10 +1,11 @@
-"""Fail-closed ownership ledger and reconciliation for generated Pi output."""
+"""Fail-closed ownership ledger and crash-safe reconciliation for generated Pi output."""
 
 from __future__ import annotations
 
 import hashlib
 import json
 import os
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
@@ -13,7 +14,7 @@ from ai_config.output_safety import validated_output_path
 
 _PI_STATE = Path(".ai-config") / "pi-ownership.json"
 _PI_PENDING = Path(".ai-config") / "pi-ownership.pending.json"
-_VERSION = 2
+_VERSION = 3
 
 
 @dataclass(frozen=True)
@@ -49,15 +50,22 @@ class PiAction:
     reason: str
 
 
+@dataclass(frozen=True)
+class _DiskState:
+    exists: bool
+    digest: str | None = None
+    executable: bool | None = None
+
+
 def digest_content(content: bytes | str) -> str:
-    """Return the exact SHA-256 digest persisted for a generated file."""
     return hashlib.sha256(content.encode() if isinstance(content, str) else content).hexdigest()
 
 
 def _safe_relative(path: Path) -> Path:
+    # Path normalizes harmless ``.`` components; reject lexical traversal before it can escape.
     if path.is_absolute() or ".." in path.parts or not path.parts:
         raise ValueError(f"Invalid Pi owned relative path: {path}")
-    return path
+    return Path(*[part for part in path.parts if part not in {"", "."}])
 
 
 def _state_path(root: Path) -> Path:
@@ -69,7 +77,7 @@ def _pending_path(root: Path) -> Path:
 
 
 def _decode_entries(
-    raw_files: object, path: Path, *, allow_v1: bool = False
+    raw_files: object, path: Path, root: Path, *, allow_v1: bool = False
 ) -> dict[Path, PiOwnedFile]:
     if not isinstance(raw_files, list):
         raise ValueError(f"Invalid Pi ownership files at {path}")
@@ -84,18 +92,17 @@ def _decode_entries(
             isinstance(value, str) and value for value in (source, relative, digest)
         ) or not isinstance(executable, bool):
             raise ValueError(f"Incomplete Pi ownership entry at {path}")
-        source, relative, digest, executable = (
-            cast(str, source),
-            cast(str, relative),
-            cast(str, digest),
-            executable,
-        )
-        if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+        if len(cast(str, digest)) != 64 or any(
+            char not in "0123456789abcdef" for char in cast(str, digest)
+        ):
             raise ValueError(f"Incomplete Pi ownership entry at {path}")
-        relative_path = _safe_relative(Path(relative))
+        relative_path = _safe_relative(Path(cast(str, relative)))
+        validated_output_path(root, relative_path)
         if relative_path in owned:
             raise ValueError(f"Ambiguous Pi ownership entry at {path}")
-        owned[relative_path] = PiOwnedFile(source, relative_path, digest, executable)
+        owned[relative_path] = PiOwnedFile(
+            cast(str, source), relative_path, cast(str, digest), executable
+        )
     return owned
 
 
@@ -114,75 +121,169 @@ def _load_json(path: Path, label: str) -> dict[str, object] | None:
 
 
 def load_pi_ownership(root: Path) -> dict[Path, PiOwnedFile]:
-    """Load a ledger only when it proves ownership of this exact target root."""
     root = root.expanduser().resolve()
     path = _state_path(root)
     payload = _load_json(path, "ownership state")
     if payload is None:
         return {}
     version = payload.get("version")
-    if version not in {1, _VERSION} or payload.get("root") != str(root):
+    if version not in {1, 2, _VERSION} or payload.get("root") != str(root):
         raise ValueError(f"Invalid Pi ownership state at {path}; refusing ambiguous cleanup")
-    return _decode_entries(payload.get("files"), path, allow_v1=version == 1)
+    return _decode_entries(payload.get("files"), path, root, allow_v1=version in {1, 2})
 
 
 def _entry_payload(entries: dict[Path, PiOwnedFile]) -> list[dict[str, object]]:
     return [
         {
-            "source_plugin": entry.source_plugin,
-            "path": entry.relative_path.as_posix(),
-            "digest": entry.digest,
-            "executable": entry.executable,
+            "source_plugin": e.source_plugin,
+            "path": e.relative_path.as_posix(),
+            "digest": e.digest,
+            "executable": e.executable,
         }
-        for _, entry in sorted(entries.items(), key=lambda pair: pair[0].as_posix())
+        for _, e in sorted(entries.items(), key=lambda p: p[0].as_posix())
     ]
 
 
 def _atomic_write(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    if temporary.exists() or temporary.is_symlink():
-        temporary.unlink()
-    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    os.replace(temporary, path)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except BaseException:
+        # Only this process-created name is ever cleaned up.
+        temporary.unlink(missing_ok=True)
+        raise
 
 
 def _write_state(root: Path, entries: dict[Path, PiOwnedFile]) -> None:
     _atomic_write(
         _state_path(root),
-        {
-            "version": _VERSION,
-            "root": str(root.expanduser().resolve()),
-            "files": _entry_payload(entries),
-        },
+        {"version": _VERSION, "root": str(root), "files": _entry_payload(entries)},
     )
 
 
-def _write_pending(root: Path, actions: list[PiAction], entries: dict[Path, PiOwnedFile]) -> None:
+def _disk_state(root: Path, relative: Path) -> _DiskState:
+    path = validated_output_path(root, relative)
+    if path.is_symlink():
+        raise ValueError(f"Refusing symlinked Pi output: {path}")
+    if not path.exists():
+        return _DiskState(False)
+    if not path.is_file():
+        raise ValueError(f"Pi output is not a regular file: {path}")
+    return _DiskState(True, digest_content(path.read_bytes()), _is_executable(path))
+
+
+def _state_payload(state: _DiskState) -> dict[str, object]:
+    return {"exists": state.exists, "digest": state.digest, "executable": state.executable}
+
+
+def _decode_disk_state(raw: object, path: Path) -> _DiskState:
+    if not isinstance(raw, dict):
+        raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+    payload = cast(dict[str, object], raw)
+    if not isinstance(payload.get("exists"), bool):
+        raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+    exists = cast(bool, payload["exists"])
+    digest, executable = payload.get("digest"), payload.get("executable")
+    if not exists:
+        if digest is not None or executable is not None:
+            raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+        return _DiskState(False)
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(c not in "0123456789abcdef" for c in digest)
+        or not isinstance(executable, bool)
+    ):
+        raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+    return _DiskState(True, digest, executable)
+
+
+def _normalize_desired(root: Path, desired: list[PiDesiredFile]) -> dict[Path, PiDesiredFile]:
+    result: dict[Path, PiDesiredFile] = {}
+    for item in desired:
+        relative = _safe_relative(item.relative_path)
+        validated_output_path(root, relative)
+        if relative in result:
+            raise ValueError(f"Pi generated path collision: {relative}")
+        result[relative] = PiDesiredFile(
+            item.source_plugin, relative, item.content, item.executable
+        )
+    return result
+
+
+def _write_pending(
+    root: Path,
+    actions: list[PiAction],
+    next_state: dict[Path, PiOwnedFile],
+    desired: dict[Path, PiDesiredFile],
+    previous: dict[Path, PiOwnedFile],
+) -> None:
+    records = []
+    for action in actions:
+        # Record what was actually on disk, not merely what an older ledger claims.
+        pre = _disk_state(root, action.path)
+        post = (
+            _DiskState(False)
+            if action.path not in next_state
+            else _DiskState(
+                True, next_state[action.path].digest, next_state[action.path].executable
+            )
+        )
+        # Preserve actions intentionally retain the observed local content, not ledger digest.
+        if action.action == "preserve_pi_output":
+            pre = post = _disk_state(root, action.path)
+        records.append(
+            {
+                "action": action.action,
+                "path": action.path.as_posix(),
+                "reason": action.reason,
+                "pre": _state_payload(pre),
+                "post": _state_payload(post),
+            }
+        )
     _atomic_write(
         _pending_path(root),
         {
             "version": _VERSION,
             "root": str(root),
-            "files": _entry_payload(entries),
-            "actions": [
-                {"action": action.action, "path": action.path.as_posix(), "reason": action.reason}
-                for action in actions
-            ],
+            "files": _entry_payload(next_state),
+            "desired": _entry_payload(
+                {
+                    p: PiOwnedFile(d.source_plugin, p, d.digest, d.executable)
+                    for p, d in desired.items()
+                }
+            ),
+            "actions": records,
         },
     )
 
 
-def _load_pending(root: Path) -> tuple[list[PiAction], dict[Path, PiOwnedFile]] | None:
+def _load_pending(
+    root: Path,
+) -> (
+    tuple[
+        list[PiAction],
+        dict[Path, PiOwnedFile],
+        dict[Path, PiOwnedFile],
+        dict[Path, tuple[_DiskState, _DiskState]],
+    ]
+    | None
+):
     path = _pending_path(root)
     payload = _load_json(path, "ownership pending transaction")
     if payload is None:
         return None
     if payload.get("version") != _VERSION or payload.get("root") != str(root):
         raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
-    entries = _decode_entries(payload.get("files"), path)
+    entries = _decode_entries(payload.get("files"), path, root)
+    wanted = _decode_entries(payload.get("desired"), path, root)
     raw_actions = payload.get("actions")
-    valid_actions = {
+    valid = {
         "create_pi_output",
         "update_pi_output",
         "remove_pi_output",
@@ -192,7 +293,7 @@ def _load_pending(root: Path) -> tuple[list[PiAction], dict[Path, PiOwnedFile]] 
     if not isinstance(raw_actions, list):
         raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
     actions: list[PiAction] = []
-    seen: set[Path] = set()
+    states: dict[Path, tuple[_DiskState, _DiskState]] = {}
     for raw in raw_actions:
         if not isinstance(raw, dict):
             raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
@@ -200,16 +301,19 @@ def _load_pending(root: Path) -> tuple[list[PiAction], dict[Path, PiOwnedFile]] 
         action, relative, reason = raw.get("action"), raw.get("path"), raw.get("reason")
         if (
             not isinstance(action, str)
-            or action not in valid_actions
+            or action not in valid
             or not isinstance(relative, str)
             or not isinstance(reason, str)
         ):
             raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
-        safe = _safe_relative(Path(relative))
-        validated_output_path(root, safe)
-        if safe in seen:
+        relative_path = _safe_relative(Path(relative))
+        validated_output_path(root, relative_path)
+        if relative_path in states:
             raise ValueError(f"Ambiguous Pi ownership pending transaction at {path}")
-        seen.add(safe)
+        states[relative_path] = (
+            _decode_disk_state(raw.get("pre"), path),
+            _decode_disk_state(raw.get("post"), path),
+        )
         actions.append(
             PiAction(
                 cast(
@@ -222,11 +326,18 @@ def _load_pending(root: Path) -> tuple[list[PiAction], dict[Path, PiOwnedFile]] 
                     ],
                     action,
                 ),
-                safe,
+                relative_path,
                 reason,
             )
         )
-    return actions, entries
+    # A journal is a complete, unambiguous state transition, not a bag of actions.
+    if set(entries) != {a.path for a in actions if states[a.path][1].exists}:
+        raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+    if not set(wanted).issubset(states) or any(
+        action.action == "remove_pi_output" for action in actions if action.path in wanted
+    ):
+        raise ValueError(f"Invalid Pi ownership pending transaction at {path}")
+    return actions, entries, wanted, states
 
 
 def _is_executable(path: Path) -> bool:
@@ -236,39 +347,30 @@ def _is_executable(path: Path) -> bool:
 def plan_pi_reconciliation(
     root: Path, desired: list[PiDesiredFile], *, retained_sources: set[str] | None = None
 ) -> tuple[list[PiAction], dict[Path, PiOwnedFile]]:
-    """Plan Pi changes without modifying disk; never adopt unowned output."""
     root = root.expanduser().resolve()
     previous = load_pi_ownership(root)
+    desired_by_path = _normalize_desired(root, desired)
     retained_sources = retained_sources or set()
-    desired_by_path: dict[Path, PiDesiredFile] = {}
-    for item in desired:
-        relative = _safe_relative(item.relative_path)
-        validated_output_path(root, relative)
-        if relative in desired_by_path:
-            raise ValueError(f"Pi generated path collision: {relative}")
-        desired_by_path[relative] = item
     actions: list[PiAction] = []
     next_state: dict[Path, PiOwnedFile] = {}
-    for relative, item in sorted(desired_by_path.items(), key=lambda pair: pair[0].as_posix()):
+    for relative, item in sorted(desired_by_path.items(), key=lambda p: p[0].as_posix()):
         path = validated_output_path(root, relative)
         old = previous.get(relative)
-        if path.is_symlink():
-            raise ValueError(f"Refusing symlinked Pi output: {path}")
-        if old is None and path.exists():
+        current = _disk_state(root, relative)
+        if old is None and current.exists:
             raise ValueError(
-                f"Unowned Pi output collision at {path}; refusing overwrite or ownership claim. "
-                "Historical unowned output is untouched (see issue #22 migration)."
+                f"Unowned Pi output collision at {path}; refusing overwrite or ownership claim. Historical unowned output is untouched (see issue #22 migration)."
             )
-        if old is not None and path.exists() and digest_content(path.read_bytes()) != old.digest:
+        if old is not None and current.exists and current.digest != old.digest:
             actions.append(
                 PiAction("preserve_pi_output", relative, "Locally modified owned output")
             )
             next_state[relative] = old
         elif (
             old is not None
-            and path.exists()
+            and current.exists
             and old.digest == item.digest
-            and _is_executable(path) == item.executable
+            and current.executable == item.executable
         ):
             actions.append(PiAction("noop_pi_output", relative, "Owned output already matches"))
             next_state[relative] = PiOwnedFile(
@@ -285,19 +387,16 @@ def plan_pi_reconciliation(
             next_state[relative] = PiOwnedFile(
                 item.source_plugin, relative, item.digest, item.executable
             )
-    for relative, old in sorted(previous.items(), key=lambda pair: pair[0].as_posix()):
+    for relative, old in sorted(previous.items(), key=lambda p: p[0].as_posix()):
         if relative in desired_by_path:
             continue
+        current = _disk_state(root, relative)
         if old.source_plugin in retained_sources:
             actions.append(
                 PiAction("preserve_pi_output", relative, "Pi source is temporarily unavailable")
             )
             next_state[relative] = old
-            continue
-        path = validated_output_path(root, relative)
-        if path.is_symlink():
-            raise ValueError(f"Refusing symlinked Pi output: {path}")
-        if path.exists() and digest_content(path.read_bytes()) != old.digest:
+        elif current.exists and current.digest != old.digest:
             actions.append(
                 PiAction("preserve_pi_output", relative, "Locally modified owned output")
             )
@@ -309,47 +408,70 @@ def plan_pi_reconciliation(
     return actions, next_state
 
 
-def _apply_actions(
-    root: Path, actions: list[PiAction], desired_by_path: dict[Path, PiDesiredFile]
-) -> None:
+def _apply_actions(root: Path, actions: list[PiAction], desired: dict[Path, PiDesiredFile]) -> None:
     for action in actions:
         path = validated_output_path(root, action.path)
         if path.is_symlink():
             raise ValueError(f"Refusing symlinked Pi output: {path}")
         if action.action in {"create_pi_output", "update_pi_output"}:
-            item = desired_by_path[action.path]
+            item = desired[action.path]
             path.parent.mkdir(parents=True, exist_ok=True)
-            temporary = path.with_suffix(path.suffix + ".ai-config-tmp")
-            if temporary.exists() or temporary.is_symlink():
-                temporary.unlink()
-            temporary.write_bytes(item.content)
-            temporary.chmod(0o755 if item.executable else 0o644)
-            os.replace(temporary, path)
+            fd, temporary_name = tempfile.mkstemp(
+                prefix=f".{path.name}.", suffix=".ai-config-tmp", dir=path.parent
+            )
+            temporary = Path(temporary_name)
+            try:
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(item.content)
+                temporary.chmod(0o755 if item.executable else 0o644)
+                os.replace(temporary, path)
+            except BaseException:
+                temporary.unlink(missing_ok=True)
+                raise
         elif action.action == "remove_pi_output":
+            # State validation before this call proves this is the exact old owned file.
             path.unlink(missing_ok=True)
 
 
 def _recover_pending(
-    root: Path, desired_by_path: dict[Path, PiDesiredFile]
+    root: Path, desired: dict[Path, PiDesiredFile], retained_sources: set[str]
 ) -> list[PiAction] | None:
     pending = _load_pending(root)
     if pending is None:
         return None
-    actions, next_state = pending
+    actions, next_state, wanted, states = pending
+    if set(desired) != set(wanted) or any(
+        (d.source_plugin, d.digest, d.executable) != (w.source_plugin, w.digest, w.executable)
+        for p, d in desired.items()
+        for w in [wanted[p]]
+    ):
+        raise ValueError(
+            "Pending Pi ownership transaction does not match current desired output; refusing unsafe recovery"
+        )
     for action in actions:
-        if action.action in {"create_pi_output", "update_pi_output", "noop_pi_output"}:
-            item = desired_by_path.get(action.path)
-            entry = next_state.get(action.path)
-            if (
-                item is None
-                or entry is None
-                or (item.source_plugin, item.digest, item.executable)
-                != (entry.source_plugin, entry.digest, entry.executable)
-            ):
+        if action.action == "remove_pi_output" and action.path in desired:
+            raise ValueError(
+                "Pending Pi ownership transaction does not match current desired output; refusing unsafe recovery"
+            )
+        if action.action == "remove_pi_output":
+            # Source id is encoded in the pre-state only in prior ledger semantics; a retained source
+            # cannot be inferred safely, so callers with any unavailable source fail closed.
+            if retained_sources:
                 raise ValueError(
-                    "Pending Pi ownership transaction does not match current desired output; refusing unsafe recovery"
+                    "Pending Pi ownership transaction has unavailable sources; refusing stale removal"
                 )
-    _apply_actions(root, actions, desired_by_path)
+        current = _disk_state(root, action.path)
+        pre, post = states[action.path]
+        if current != pre and current != post:
+            raise ValueError(
+                f"Pending Pi ownership transaction diverged at {action.path}; preserving user changes"
+            )
+    apply_now = [
+        a
+        for a in actions
+        if _disk_state(root, a.path) == states[a.path][0] and states[a.path][0] != states[a.path][1]
+    ]
+    _apply_actions(root, apply_now, desired)
     _write_state(root, next_state)
     _pending_path(root).unlink()
     return actions
@@ -362,18 +484,58 @@ def apply_pi_reconciliation(
     dry_run: bool = False,
     retained_sources: set[str] | None = None,
 ) -> list[PiAction]:
-    """Reconcile Pi output with a durable retryable transaction journal."""
     root = root.expanduser().resolve()
-    desired_by_path = {item.relative_path: item for item in desired}
-    if not dry_run:
-        recovered = _recover_pending(root, desired_by_path)
+    desired_by_path = _normalize_desired(root, desired)
+    retained_sources = retained_sources or set()
+    pending = _load_pending(root)
+    if pending is not None:
+        # Recovery validation is deliberately identical for preview and apply.
+        if dry_run:
+            _recover_pending_plan(root, desired_by_path, retained_sources, pending)
+            return pending[0]
+        recovered = _recover_pending(root, desired_by_path, retained_sources)
         if recovered is not None:
             return recovered
-    actions, next_state = plan_pi_reconciliation(root, desired, retained_sources=retained_sources)
+    actions, next_state = plan_pi_reconciliation(
+        root, list(desired_by_path.values()), retained_sources=retained_sources
+    )
     if dry_run:
         return actions
-    _write_pending(root, actions, next_state)
+    previous = load_pi_ownership(root)
+    _write_pending(root, actions, next_state, desired_by_path, previous)
     _apply_actions(root, actions, desired_by_path)
     _write_state(root, next_state)
     _pending_path(root).unlink()
     return actions
+
+
+def _recover_pending_plan(
+    root: Path,
+    desired: dict[Path, PiDesiredFile],
+    retained_sources: set[str],
+    pending: tuple[
+        list[PiAction],
+        dict[Path, PiOwnedFile],
+        dict[Path, PiOwnedFile],
+        dict[Path, tuple[_DiskState, _DiskState]],
+    ],
+) -> None:
+    actions, _next, wanted, states = pending
+    if set(desired) != set(wanted) or any(
+        (d.source_plugin, d.digest, d.executable)
+        != (wanted[p].source_plugin, wanted[p].digest, wanted[p].executable)
+        for p, d in desired.items()
+    ):
+        raise ValueError(
+            "Pending Pi ownership transaction does not match current desired output; refusing unsafe recovery"
+        )
+    for action in actions:
+        if action.action == "remove_pi_output" and retained_sources:
+            raise ValueError(
+                "Pending Pi ownership transaction has unavailable sources; refusing stale removal"
+            )
+        current = _disk_state(root, action.path)
+        if current != states[action.path][0] and current != states[action.path][1]:
+            raise ValueError(
+                f"Pending Pi ownership transaction diverged at {action.path}; preserving user changes"
+            )

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -243,10 +243,9 @@ def _atomic_write(path: Path, payload: dict[str, object]) -> None:
 
 def _write_state(root: Path, domain: PiOwnershipDomain, entries: dict[Path, PiOwnedFile]) -> None:
     path = _state_path(root)
-    # A first conversion with no emitted files still records its selected domain.
-    # Only an existing ledger reconciled down to no files releases the root.
-    if not entries and path.exists():
-        path.unlink()
+    # No owned files means there is no ownership domain to reserve or track.
+    if not entries:
+        path.unlink(missing_ok=True)
         return
     _atomic_write(
         path,

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -129,7 +129,9 @@ def load_pi_ownership(root: Path) -> dict[Path, PiOwnedFile]:
     version = payload.get("version")
     if version not in {1, 2, _VERSION} or payload.get("root") != str(root):
         raise ValueError(f"Invalid Pi ownership state at {path}; refusing ambiguous cleanup")
-    return _decode_entries(payload.get("files"), path, root, allow_v1=version in {1, 2})
+    # Version 1 predates executable-mode ownership. Later schemas must carry it
+    # explicitly so malformed state never makes cleanup decisions for us.
+    return _decode_entries(payload.get("files"), path, root, allow_v1=version == 1)
 
 
 def _entry_payload(entries: dict[Path, PiOwnedFile]) -> list[dict[str, object]]:
@@ -407,6 +409,25 @@ def plan_pi_reconciliation(
     return actions, next_state
 
 
+def _prune_empty_owned_ancestors(root: Path, relative: Path) -> None:
+    """Remove empty generated parents without crossing Pi's managed root boundary."""
+    # User output lives below .pi/agent; project output lives directly below .pi.
+    boundary = root / ".pi" / "agent" if relative.parts[:2] == (".pi", "agent") else root / ".pi"
+    directory = validated_output_path(root, relative).parent
+    while directory != boundary:
+        if directory.is_symlink():
+            raise ValueError(f"Refusing symlinked Pi output directory: {directory}")
+        try:
+            directory.rmdir()
+        except FileNotFoundError:
+            directory = directory.parent
+        except OSError:
+            # A user file (or another owned file) remains; never remove its directory.
+            break
+        else:
+            directory = directory.parent
+
+
 def _apply_actions(root: Path, actions: list[PiAction], desired: dict[Path, PiDesiredFile]) -> None:
     for action in actions:
         path = validated_output_path(root, action.path)
@@ -430,6 +451,7 @@ def _apply_actions(root: Path, actions: list[PiAction], desired: dict[Path, PiDe
         elif action.action == "remove_pi_output":
             # State validation before this call proves this is the exact old owned file.
             path.unlink(missing_ok=True)
+            _prune_empty_owned_ancestors(root, action.path)
 
 
 def _recover_pending(

--- a/src/ai_config/pi_ownership.py
+++ b/src/ai_config/pi_ownership.py
@@ -1,0 +1,203 @@
+"""Fail-closed ownership ledger and reconciliation for generated Pi output."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from ai_config.output_safety import validated_output_path
+
+_PI_STATE = Path(".ai-config") / "pi-ownership.json"
+_VERSION = 1
+
+
+@dataclass(frozen=True)
+class PiOwnedFile:
+    source_plugin: str
+    relative_path: Path
+    digest: str
+
+
+@dataclass(frozen=True)
+class PiDesiredFile:
+    source_plugin: str
+    relative_path: Path
+    content: bytes
+    executable: bool = False
+
+    @property
+    def digest(self) -> str:
+        return digest_content(self.content)
+
+
+@dataclass(frozen=True)
+class PiAction:
+    action: Literal[
+        "create_pi_output",
+        "update_pi_output",
+        "remove_pi_output",
+        "noop_pi_output",
+        "preserve_pi_output",
+    ]
+    path: Path
+    reason: str
+
+
+def digest_content(content: bytes | str) -> str:
+    """Return the exact SHA-256 digest persisted for a generated file."""
+    return hashlib.sha256(content.encode() if isinstance(content, str) else content).hexdigest()
+
+
+def _safe_relative(path: Path) -> Path:
+    if path.is_absolute() or ".." in path.parts or not path.parts:
+        raise ValueError(f"Invalid Pi owned relative path: {path}")
+    return path
+
+
+def _state_path(root: Path) -> Path:
+    return validated_output_path(root, _PI_STATE)
+
+
+def load_pi_ownership(root: Path) -> dict[Path, PiOwnedFile]:
+    """Load a ledger only when it proves ownership of this exact target root."""
+    root = root.expanduser().resolve()
+    path = _state_path(root)
+    if not path.exists():
+        return {}
+    if path.is_symlink():
+        raise ValueError(f"Refusing symlinked Pi ownership state: {path}")
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Invalid Pi ownership state at {path}: {error}") from error
+    if (
+        not isinstance(payload, dict)
+        or payload.get("version") != _VERSION
+        or payload.get("root") != str(root)
+    ):
+        raise ValueError(f"Invalid Pi ownership state at {path}; refusing ambiguous cleanup")
+    raw_files = payload.get("files")
+    if not isinstance(raw_files, list):
+        raise ValueError(f"Invalid Pi ownership files at {path}")
+    owned: dict[Path, PiOwnedFile] = {}
+    for raw in raw_files:
+        if not isinstance(raw, dict):
+            raise ValueError(f"Invalid Pi ownership entry at {path}")
+        source, relative, digest = raw.get("source_plugin"), raw.get("path"), raw.get("digest")
+        if not all(isinstance(value, str) and value for value in (source, relative, digest)):
+            raise ValueError(f"Incomplete Pi ownership entry at {path}")
+        relative_path = _safe_relative(Path(relative))
+        if relative_path in owned or len(digest) != 64:
+            raise ValueError(f"Ambiguous Pi ownership entry at {path}")
+        validated_output_path(root, relative_path)
+        owned[relative_path] = PiOwnedFile(source, relative_path, digest)
+    return owned
+
+
+def plan_pi_reconciliation(
+    root: Path, desired: list[PiDesiredFile]
+) -> tuple[list[PiAction], dict[Path, PiOwnedFile]]:
+    """Plan Pi changes without modifying disk; never adopt unowned output."""
+    root = root.expanduser().resolve()
+    previous = load_pi_ownership(root)
+    desired_by_path: dict[Path, PiDesiredFile] = {}
+    for item in desired:
+        relative = _safe_relative(item.relative_path)
+        validated_output_path(root, relative)
+        if relative in desired_by_path:
+            raise ValueError(f"Pi generated path collision: {relative}")
+        desired_by_path[relative] = item
+    actions: list[PiAction] = []
+    next_state: dict[Path, PiOwnedFile] = {}
+    for relative, item in sorted(desired_by_path.items(), key=lambda pair: pair[0].as_posix()):
+        path = validated_output_path(root, relative)
+        old = previous.get(relative)
+        if path.exists() and path.is_symlink():
+            raise ValueError(f"Refusing symlinked Pi output: {path}")
+        if old is None and path.exists():
+            raise ValueError(
+                f"Unowned Pi output collision at {path}; refusing overwrite or ownership claim. "
+                "Historical unowned output is untouched (see issue #22 migration)."
+            )
+        if old is not None and path.exists() and digest_content(path.read_bytes()) != old.digest:
+            actions.append(
+                PiAction("preserve_pi_output", relative, "Locally modified owned output")
+            )
+            next_state[relative] = old
+        elif old is not None and path.exists() and old.digest == item.digest:
+            actions.append(PiAction("noop_pi_output", relative, "Owned output already matches"))
+            next_state[relative] = PiOwnedFile(item.source_plugin, relative, item.digest)
+        else:
+            actions.append(
+                PiAction(
+                    "update_pi_output" if old else "create_pi_output",
+                    relative,
+                    "Generated Pi output changed",
+                )
+            )
+            next_state[relative] = PiOwnedFile(item.source_plugin, relative, item.digest)
+    for relative, old in sorted(previous.items(), key=lambda pair: pair[0].as_posix()):
+        if relative in desired_by_path:
+            continue
+        path = validated_output_path(root, relative)
+        if path.exists() and (path.is_symlink() or digest_content(path.read_bytes()) != old.digest):
+            actions.append(
+                PiAction("preserve_pi_output", relative, "Locally modified owned output")
+            )
+            next_state[relative] = old
+        else:
+            actions.append(
+                PiAction("remove_pi_output", relative, "Pi source or target was removed")
+            )
+    return actions, next_state
+
+
+def _write_state(root: Path, entries: dict[Path, PiOwnedFile]) -> None:
+    path = _state_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": _VERSION,
+        "root": str(root.expanduser().resolve()),
+        "files": [
+            {
+                "source_plugin": entry.source_plugin,
+                "path": entry.relative_path.as_posix(),
+                "digest": entry.digest,
+            }
+            for _, entry in sorted(entries.items(), key=lambda pair: pair[0].as_posix())
+        ],
+    }
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    os.replace(temporary, path)
+
+
+def apply_pi_reconciliation(
+    root: Path, desired: list[PiDesiredFile], *, dry_run: bool = False
+) -> list[PiAction]:
+    """Reconcile and checkpoint only after all planned filesystem mutations succeed."""
+    root = root.expanduser().resolve()
+    actions, next_state = plan_pi_reconciliation(root, desired)
+    if dry_run:
+        return actions
+    desired_by_path = {item.relative_path: item for item in desired}
+    for action in actions:
+        path = validated_output_path(root, action.path)
+        if action.action in {"create_pi_output", "update_pi_output"}:
+            item = desired_by_path[action.path]
+            path.parent.mkdir(parents=True, exist_ok=True)
+            temporary = path.with_suffix(path.suffix + ".ai-config-tmp")
+            if temporary.exists() or temporary.is_symlink():
+                temporary.unlink()
+            temporary.write_bytes(item.content)
+            if item.executable:
+                temporary.chmod(temporary.stat().st_mode | 0o111)
+            os.replace(temporary, path)
+        elif action.action == "remove_pi_output":
+            path.unlink(missing_ok=True)
+    _write_state(root, next_state)
+    return actions

--- a/src/ai_config/types.py
+++ b/src/ai_config/types.py
@@ -26,6 +26,13 @@ SyncActionName: TypeAlias = (
         "register_marketplace",
     ]
     | CodexLifecycleActionName
+    | Literal[
+        "create_pi_output",
+        "update_pi_output",
+        "remove_pi_output",
+        "noop_pi_output",
+        "preserve_pi_output",
+    ]
 )
 
 

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -28,7 +28,7 @@ from ai_config.converters.ir import (
     TargetTool,
     TextFile,
 )
-from ai_config.pi_ownership import load_pi_ownership
+from ai_config.pi_ownership import load_pi_ownership, standalone_pi_source_identity
 
 FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "sample-plugins"
 
@@ -1183,8 +1183,8 @@ class TestStandalonePiOwnership:
     """Standalone Pi conversion uses the same ownership boundary as sync."""
 
     @staticmethod
-    def _plugin(root: Path, plugin_id: str, skill: str) -> Path:
-        plugin = root / plugin_id
+    def _plugin(root: Path, plugin_id: str, skill: str, *, directory: str | None = None) -> Path:
+        plugin = root / (directory or plugin_id)
         (plugin / ".claude-plugin").mkdir(parents=True)
         (plugin / ".claude-plugin/plugin.json").write_text(
             json.dumps({"name": plugin_id, "version": "1.0.0", "skills": "./skills"})
@@ -1210,7 +1210,9 @@ class TestStandalonePiOwnership:
         report = convert_plugin(plugin, [TargetTool.PI], output, scope)[TargetTool.PI]
 
         assert (output / relative).is_file()
-        assert load_pi_ownership(output)[relative].source_plugin == "alpha-plugin"
+        assert load_pi_ownership(output)[relative].source_plugin == standalone_pi_source_identity(
+            plugin, "alpha-plugin"
+        )
         assert [file.action for file in report.files_written] == ["create"]
 
     def test_standalone_pi_reconciles_only_its_prior_output(self, tmp_path: Path) -> None:
@@ -1230,8 +1232,8 @@ class TestStandalonePiOwnership:
         assert (output / ".pi/skills/alpha-plugin-gamma/SKILL.md").is_file()
         assert (output / ".pi/skills/beta-plugin-beta/SKILL.md").is_file()
         assert {entry.source_plugin for entry in load_pi_ownership(output).values()} == {
-            "alpha-plugin",
-            "beta-plugin",
+            standalone_pi_source_identity(alpha, "alpha-plugin"),
+            standalone_pi_source_identity(beta, "beta-plugin"),
         }
         assert {file.action for file in report.files_written} == {"create", "remove", "preserve"}
 
@@ -1281,16 +1283,55 @@ class TestStandalonePiOwnership:
         assert (output / ".pi/skills/alpha-plugin-alpha/SKILL.md").is_file()
         assert load_pi_ownership(output)
 
-    def test_convert_plugin_simple_records_pi_ownership(self, tmp_path: Path) -> None:
+    def test_standalone_sources_with_shared_manifest_id_cannot_take_over_output(
+        self, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "output"
+        first = self._plugin(tmp_path, "shared-plugin", "alpha", directory="first")
+        second = self._plugin(tmp_path, "shared-plugin", "alpha", directory="second")
+        relative = Path(".pi/skills/shared-plugin-alpha/SKILL.md")
+        convert_plugin(first, [TargetTool.PI], output)
+        first_content = (output / relative).read_text()
+
+        for content in ("alpha\n", "changed\n"):
+            (second / "skills/alpha/SKILL.md").write_text(
+                f"---\nname: alpha\ndescription: alpha\n---\n{content}"
+            )
+            with pytest.raises(ValueError, match="Pi output ownership collision") as error:
+                convert_plugin(second, [TargetTool.PI], output)
+            assert "standalone:shared-plugin:" in str(error.value)
+            assert (output / relative).read_text() == first_content
+
+    def test_standalone_sources_with_shared_manifest_id_retain_renamed_output(
+        self, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "output"
+        first = self._plugin(tmp_path, "shared-plugin", "alpha", directory="first")
+        second = self._plugin(tmp_path, "shared-plugin", "beta", directory="second")
+        convert_plugin(first, [TargetTool.PI], output)
+        convert_plugin(second, [TargetTool.PI], output)
+
+        assert (output / ".pi/skills/shared-plugin-alpha/SKILL.md").is_file()
+        assert (output / ".pi/skills/shared-plugin-beta/SKILL.md").is_file()
+
+    def test_same_standalone_source_rerun_is_convergent(self, tmp_path: Path) -> None:
+        output = tmp_path / "output"
+        plugin = self._plugin(tmp_path, "alpha-plugin", "alpha")
+        convert_plugin(plugin, [TargetTool.PI], output)
+
+        report = convert_plugin(plugin, [TargetTool.PI], output)[TargetTool.PI]
+
+        assert [file.action for file in report.files_written] == ["noop"]
+
+    def test_convert_plugin_simple_matches_standalone_owner_identity(self, tmp_path: Path) -> None:
         output = tmp_path / "output"
         plugin = self._plugin(tmp_path, "alpha-plugin", "alpha")
 
         convert_plugin_simple(plugin, TargetTool.PI, output)
 
-        assert (
-            load_pi_ownership(output)[Path(".pi/skills/alpha-plugin-alpha/SKILL.md")].source_plugin
-            == "alpha-plugin"
-        )
+        assert load_pi_ownership(output)[
+            Path(".pi/skills/alpha-plugin-alpha/SKILL.md")
+        ].source_plugin == standalone_pi_source_identity(plugin, "alpha-plugin")
 
 
 class TestPreviewConversion:

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from ai_config.converters.claude_parser import parse_claude_plugin
-from ai_config.converters.convert import convert_plugin, preview_conversion
+from ai_config.converters.convert import convert_plugin, convert_plugin_simple, preview_conversion
 from ai_config.converters.emitters import (
     CodexEmitter,
     CursorEmitter,
@@ -28,6 +28,7 @@ from ai_config.converters.ir import (
     TargetTool,
     TextFile,
 )
+from ai_config.pi_ownership import load_pi_ownership
 
 FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "sample-plugins"
 
@@ -1176,6 +1177,120 @@ class TestDryRun:
             / ".ai-config/codex/marketplaces/ai-config-dev-tools/plugins/dev-tools/skills"
         )
         assert package_dir.exists()
+
+
+class TestStandalonePiOwnership:
+    """Standalone Pi conversion uses the same ownership boundary as sync."""
+
+    @staticmethod
+    def _plugin(root: Path, plugin_id: str, skill: str) -> Path:
+        plugin = root / plugin_id
+        (plugin / ".claude-plugin").mkdir(parents=True)
+        (plugin / ".claude-plugin/plugin.json").write_text(
+            json.dumps({"name": plugin_id, "version": "1.0.0", "skills": "./skills"})
+        )
+        skill_file = plugin / "skills" / skill / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text(f"---\nname: {skill}\ndescription: {skill}\n---\n{skill}\n")
+        return plugin
+
+    @pytest.mark.parametrize(
+        ("scope", "relative"),
+        [
+            (InstallScope.PROJECT, Path(".pi/skills/alpha-plugin-alpha/SKILL.md")),
+            (InstallScope.USER, Path(".pi/agent/skills/alpha-plugin-alpha/SKILL.md")),
+        ],
+    )
+    def test_standalone_pi_records_project_and_user_output(
+        self, tmp_path: Path, scope: InstallScope, relative: Path
+    ) -> None:
+        output = tmp_path / "output"
+        plugin = self._plugin(tmp_path, "alpha-plugin", "alpha")
+
+        report = convert_plugin(plugin, [TargetTool.PI], output, scope)[TargetTool.PI]
+
+        assert (output / relative).is_file()
+        assert load_pi_ownership(output)[relative].source_plugin == "alpha-plugin"
+        assert [file.action for file in report.files_written] == ["create"]
+
+    def test_standalone_pi_reconciles_only_its_prior_output(self, tmp_path: Path) -> None:
+        output = tmp_path / "output"
+        alpha = self._plugin(tmp_path, "alpha-plugin", "alpha")
+        beta = self._plugin(tmp_path, "beta-plugin", "beta")
+        convert_plugin(alpha, [TargetTool.PI], output)
+        convert_plugin(beta, [TargetTool.PI], output)
+        old = output / ".pi/skills/alpha-plugin-alpha/SKILL.md"
+        renamed = alpha / "skills/gamma"
+        (alpha / "skills/alpha").rename(renamed)
+        (renamed / "SKILL.md").write_text("---\nname: gamma\ndescription: gamma\n---\ngamma\n")
+
+        report = convert_plugin(alpha, [TargetTool.PI], output)[TargetTool.PI]
+
+        assert not old.exists()
+        assert (output / ".pi/skills/alpha-plugin-gamma/SKILL.md").is_file()
+        assert (output / ".pi/skills/beta-plugin-beta/SKILL.md").is_file()
+        assert {entry.source_plugin for entry in load_pi_ownership(output).values()} == {
+            "alpha-plugin",
+            "beta-plugin",
+        }
+        assert {file.action for file in report.files_written} == {"create", "remove", "preserve"}
+
+    def test_standalone_pi_preserves_local_changes_and_rejects_collisions(
+        self, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "output"
+        plugin = self._plugin(tmp_path, "alpha-plugin", "alpha")
+        convert_plugin(plugin, [TargetTool.PI], output)
+        owned = output / ".pi/skills/alpha-plugin-alpha/SKILL.md"
+        owned.write_text("local")
+        (plugin / "skills/alpha").rename(plugin / "skills/renamed")
+        preserved = convert_plugin(plugin, [TargetTool.PI], output)[TargetTool.PI]
+        assert owned.read_text() == "local"
+        assert "preserve" in {file.action for file in preserved.files_written}
+
+        collision_output = tmp_path / "collision"
+        collision = collision_output / ".pi/skills/collision-plugin-alpha/SKILL.md"
+        collision.parent.mkdir(parents=True)
+        collision.write_text("local")
+        with pytest.raises(ValueError, match="Unowned Pi output collision"):
+            convert_plugin(
+                self._plugin(tmp_path, "collision-plugin", "alpha"),
+                [TargetTool.PI],
+                collision_output,
+            )
+
+    def test_standalone_pi_dry_run_and_all_target_conversion(self, tmp_path: Path) -> None:
+        output = tmp_path / "output"
+        plugin = self._plugin(tmp_path, "alpha-plugin", "alpha")
+
+        dry_run = convert_plugin(plugin, [TargetTool.PI], output, dry_run=True)[TargetTool.PI]
+        assert [file.action for file in dry_run.files_written] == ["create"]
+        assert not output.exists()
+
+        reports = convert_plugin(
+            plugin,
+            [TargetTool.CODEX, TargetTool.CURSOR, TargetTool.OPENCODE, TargetTool.PI],
+            output,
+        )
+        assert set(reports) == {
+            TargetTool.CODEX,
+            TargetTool.CURSOR,
+            TargetTool.OPENCODE,
+            TargetTool.PI,
+        }
+        assert (output / ".pi/skills/alpha-plugin-alpha/SKILL.md").is_file()
+        assert load_pi_ownership(output)
+
+    def test_convert_plugin_simple_records_pi_ownership(self, tmp_path: Path) -> None:
+        output = tmp_path / "output"
+        plugin = self._plugin(tmp_path, "alpha-plugin", "alpha")
+
+        convert_plugin_simple(plugin, TargetTool.PI, output)
+
+        assert (
+            load_pi_ownership(output)[Path(".pi/skills/alpha-plugin-alpha/SKILL.md")].source_plugin
+            == "alpha-plugin"
+        )
 
 
 class TestPreviewConversion:

--- a/tests/unit/converters/test_conversion.py
+++ b/tests/unit/converters/test_conversion.py
@@ -28,7 +28,12 @@ from ai_config.converters.ir import (
     TargetTool,
     TextFile,
 )
-from ai_config.pi_ownership import load_pi_ownership, standalone_pi_source_identity
+from ai_config.pi_ownership import (
+    PiDesiredFile,
+    apply_pi_reconciliation,
+    load_pi_ownership,
+    standalone_pi_source_identity,
+)
 
 FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "sample-plugins"
 
@@ -1269,19 +1274,83 @@ class TestStandalonePiOwnership:
         assert [file.action for file in dry_run.files_written] == ["create"]
         assert not output.exists()
 
-        reports = convert_plugin(
-            plugin,
-            [TargetTool.CODEX, TargetTool.CURSOR, TargetTool.OPENCODE, TargetTool.PI],
-            output,
-        )
-        assert set(reports) == {
-            TargetTool.CODEX,
-            TargetTool.CURSOR,
-            TargetTool.OPENCODE,
-            TargetTool.PI,
-        }
+        targets = [TargetTool.CODEX, TargetTool.CURSOR, TargetTool.OPENCODE, TargetTool.PI]
+        reports = convert_plugin(plugin, targets, output)
+        assert list(reports) == targets
+        assert (output / ".ai-config/codex").is_dir()
+        assert (output / ".cursor").is_dir()
+        assert (output / ".opencode/skills/alpha-plugin-alpha/SKILL.md").is_file()
         assert (output / ".pi/skills/alpha-plugin-alpha/SKILL.md").is_file()
         assert load_pi_ownership(output)
+
+    @staticmethod
+    def _assert_no_non_pi_output(output: Path) -> None:
+        assert not (output / ".ai-config/codex").exists()
+        assert not (output / ".cursor").exists()
+        assert not (output / ".opencode").exists()
+        assert not (output / "opencode.json").exists()
+        assert not (output / "opencode.lsp.json").exists()
+
+    @pytest.mark.parametrize(
+        "invalid_ledger",
+        [
+            '{"version": 1, "files": []}',
+            "not json",
+        ],
+        ids=["legacy-schema", "malformed"],
+    )
+    def test_pi_ledger_preflight_blocks_all_target_writes(
+        self, tmp_path: Path, invalid_ledger: str
+    ) -> None:
+        output = tmp_path / "output"
+        ledger = output / ".ai-config/pi-ownership.json"
+        ledger.parent.mkdir(parents=True)
+        ledger.write_text(invalid_ledger)
+
+        with pytest.raises(ValueError):
+            convert_plugin(
+                self._plugin(tmp_path, "alpha-plugin", "alpha"),
+                [TargetTool.CODEX, TargetTool.CURSOR, TargetTool.OPENCODE, TargetTool.PI],
+                output,
+                best_effort=True,
+            )
+
+        self._assert_no_non_pi_output(output)
+        assert ledger.read_text() == invalid_ledger
+
+    def test_pi_domain_conflict_preflight_blocks_all_target_writes(self, tmp_path: Path) -> None:
+        output = tmp_path / "output"
+        apply_pi_reconciliation(
+            output,
+            [PiDesiredFile("sync-plugin@1", Path(".pi/sync.md"), b"sync")],
+            ownership_domain="sync",
+        )
+
+        with pytest.raises(ValueError, match="ownership domain conflict"):
+            convert_plugin(
+                self._plugin(tmp_path, "alpha-plugin", "alpha"),
+                [TargetTool.CODEX, TargetTool.CURSOR, TargetTool.OPENCODE, TargetTool.PI],
+                output,
+            )
+
+        self._assert_no_non_pi_output(output)
+        assert (output / ".pi/sync.md").read_text() == "sync"
+
+    def test_unowned_pi_collision_preflight_blocks_all_target_writes(self, tmp_path: Path) -> None:
+        output = tmp_path / "output"
+        collision = output / ".pi/skills/alpha-plugin-alpha/SKILL.md"
+        collision.parent.mkdir(parents=True)
+        collision.write_text("local")
+
+        with pytest.raises(ValueError, match="Unowned Pi output collision"):
+            convert_plugin(
+                self._plugin(tmp_path, "alpha-plugin", "alpha"),
+                [TargetTool.CODEX, TargetTool.CURSOR, TargetTool.OPENCODE, TargetTool.PI],
+                output,
+            )
+
+        self._assert_no_non_pi_output(output)
+        assert collision.read_text() == "local"
 
     def test_standalone_sources_with_shared_manifest_id_cannot_take_over_output(
         self, tmp_path: Path

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for ai_config.cli module."""
 
 import json
+import shutil
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
@@ -8,11 +9,11 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
-from ai_config.adapters.claude import CommandResult
+from ai_config.adapters.claude import CommandResult, InstalledMarketplace, InstalledPlugin
 from ai_config.cli import main
 from ai_config.converters.ir import PluginIdentity, TargetTool
 from ai_config.converters.report import ConversionReport
-from ai_config.types import PluginStatus, StatusResult, SyncAction, SyncResult
+from ai_config.types import PluginSource, PluginStatus, StatusResult, SyncAction, SyncResult
 
 
 @pytest.fixture
@@ -59,6 +60,69 @@ def _stub_report(target: TargetTool) -> ConversionReport:
     """Create a minimal conversion report for CLI tests."""
     identity = PluginIdentity(plugin_id="test-plugin", name="test-plugin", version="1.0.0")
     return ConversionReport(source_plugin=identity, target_tool=target)
+
+
+def test_pi_cli_verify_and_json_report_no_false_drift(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Drive sync/status verification through Click with actual Pi output and only CLI inventory patched."""
+    source = tmp_path / "source"
+    shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    output = tmp_path / "output"
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        dedent(f"""
+        version: 1
+        targets:
+          - type: claude
+            config:
+              marketplaces:
+                local:
+                  source: local
+                  path: {source}
+              plugins:
+                - id: dev-tools@local
+                  scope: project
+                  enabled: true
+              conversion:
+                targets: [pi]
+                scope: project
+                output_dir: {output}
+        """)
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    installed = [InstalledPlugin("dev-tools@local", "1", "project", True, str(source))]
+    with (
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
+        patch(
+            "ai_config.operations.claude.list_installed_marketplaces",
+            return_value=(
+                [InstalledMarketplace("local", PluginSource.LOCAL, "", str(source))],
+                [],
+            ),
+        ),
+    ):
+        first = runner.invoke(main, ["sync", "-c", str(config), "--verify"])
+        sync_json = runner.invoke(main, ["sync", "-c", str(config), "--verify", "--json"])
+        status = runner.invoke(main, ["status", "-c", str(config), "--verify"])
+        status_json = runner.invoke(main, ["status", "-c", str(config), "--verify", "--json"])
+
+    assert (
+        first.exit_code == sync_json.exit_code == status.exit_code == status_json.exit_code == 0
+    ), (
+        first.output,
+        sync_json.output,
+        status.output,
+        status_json.output,
+    )
+    payload = json.loads(sync_json.output)
+    assert payload["verification"]["discrepancies"] == []
+    assert {item["action"] for item in payload["targets"]["claude"]["completed_actions"]} == {
+        "noop_pi_output"
+    }
+    assert "All in sync" in first.output
+    assert "Out of sync" not in status.output
+    assert json.loads(status_json.output)["errors"] == []
 
 
 class TestMainGroup:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -477,13 +477,43 @@ class TestConvertCommand:
         call_args = mock_convert.call_args.kwargs
         assert call_args["output_dir"] == Path(tmp_path / "home")
 
-    def test_convert_rejects_unmanaged_pi_output(
-        self, runner: CliRunner, minimal_plugin: Path
+    def test_convert_pi_records_standalone_ownership(
+        self, runner: CliRunner, minimal_plugin: Path, tmp_path: Path
     ) -> None:
-        result = runner.invoke(main, ["convert", str(minimal_plugin), "--target", "pi"])
+        output = tmp_path / "output"
+        result = runner.invoke(
+            main, ["convert", str(minimal_plugin), "--target", "pi", "--output", str(output)]
+        )
 
-        assert result.exit_code == 2
-        assert "Standalone Pi conversion is disabled" in result.output
+        assert result.exit_code == 0, result.output
+        assert (output / ".ai-config/pi-ownership.json").is_file()
+        assert "Standalone Pi conversion is disabled" not in result.output
+
+    def test_convert_pi_dry_run_reports_ownership_actions(
+        self, runner: CliRunner, minimal_plugin: Path, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "output"
+        skill = minimal_plugin / "skills" / "thing" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text("---\nname: thing\ndescription: thing\n---\nthing\n")
+        result = runner.invoke(
+            main,
+            [
+                "convert",
+                str(minimal_plugin),
+                "--target",
+                "pi",
+                "--output",
+                str(output),
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert '"action": "create"' in result.output
+        assert not output.exists()
 
     def test_convert_writes_report_file(
         self, runner: CliRunner, minimal_plugin: Path, tmp_path: Path

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -481,6 +481,9 @@ class TestConvertCommand:
         self, runner: CliRunner, minimal_plugin: Path, tmp_path: Path
     ) -> None:
         output = tmp_path / "output"
+        skill = minimal_plugin / "skills" / "thing" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text("---\nname: thing\ndescription: thing\n---\nthing\n")
         result = runner.invoke(
             main, ["convert", str(minimal_plugin), "--target", "pi", "--output", str(output)]
         )
@@ -488,6 +491,26 @@ class TestConvertCommand:
         assert result.exit_code == 0, result.output
         assert (output / ".ai-config/pi-ownership.json").is_file()
         assert "Standalone Pi conversion is disabled" not in result.output
+
+    def test_convert_all_preflights_pi_before_other_target_writes(
+        self, runner: CliRunner, minimal_plugin: Path, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "output"
+        ledger = output / ".ai-config/pi-ownership.json"
+        ledger.parent.mkdir(parents=True)
+        ledger.write_text('{"version": 1, "files": []}')
+
+        with pytest.raises(ValueError, match="Unsupported Pi ownership state schema"):
+            runner.invoke(
+                main,
+                ["convert", str(minimal_plugin), "-t", "all", "--output", str(output)],
+                catch_exceptions=False,
+            )
+
+        assert not (output / ".ai-config/codex").exists()
+        assert not (output / ".cursor").exists()
+        assert not (output / ".opencode").exists()
+        assert not (output / "opencode.json").exists()
 
     def test_convert_pi_dry_run_reports_ownership_actions(
         self, runner: CliRunner, minimal_plugin: Path, tmp_path: Path

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -413,6 +413,14 @@ class TestConvertCommand:
         call_args = mock_convert.call_args.kwargs
         assert call_args["output_dir"] == Path(tmp_path / "home")
 
+    def test_convert_rejects_unmanaged_pi_output(
+        self, runner: CliRunner, minimal_plugin: Path
+    ) -> None:
+        result = runner.invoke(main, ["convert", str(minimal_plugin), "--target", "pi"])
+
+        assert result.exit_code == 2
+        assert "Standalone Pi conversion is disabled" in result.output
+
     def test_convert_writes_report_file(
         self, runner: CliRunner, minimal_plugin: Path, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -21,10 +21,12 @@ from ai_config.operations import (
     _load_conversion_cache,
     get_status,
     sync_config,
+    sync_discrepancies,
     sync_target,
     update_plugins,
     verify_sync,
 )
+from ai_config.pi_ownership import PiDesiredFile, apply_pi_reconciliation
 from ai_config.types import (
     AIConfig,
     ClaudeTargetConfig,
@@ -85,6 +87,83 @@ def mock_installed_marketplaces() -> list[InstalledMarketplace]:
             install_location="/path/to/marketplace",
         ),
     ]
+
+
+def test_noop_pi_output_is_not_a_verification_discrepancy() -> None:
+    from ai_config.types import SyncAction, SyncResult
+
+    result = SyncResult(
+        actions_taken=[SyncAction("noop_pi_output", ".pi/skill", reason="matches")]
+    )
+    assert sync_discrepancies({"claude": result}) == []
+
+
+def test_pi_parse_error_preserves_owned_output_before_any_reconciliation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    output = tmp_path / "home"
+    apply_pi_reconciliation(
+        output, [PiDesiredFile("plugin1@my-marketplace", Path(".pi/old"), b"old")]
+    )
+    broken_source = tmp_path / "broken"
+    broken_source.mkdir()
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            plugins=(PluginConfig(id="plugin1@my-marketplace", scope="user", enabled=True),),
+            conversion=ConversionConfig(targets=("pi",), scope="user"),
+        ),
+    )
+    monkeypatch.setattr(Path, "home", lambda: output)
+    with (
+        patch(
+            "ai_config.operations.claude.list_installed_plugins",
+            return_value=(
+                [InstalledPlugin("plugin1@my-marketplace", "1", "user", True, str(broken_source))],
+                [],
+            ),
+        ),
+        patch(
+            "ai_config.operations._load_conversion_cache",
+            return_value={"version": 7, "entries": {}},
+        ),
+    ):
+        result = sync_target(target)
+    assert not result.success
+    assert any("Pi conversion failed" in error for error in result.errors)
+    assert (output / ".pi/old").read_bytes() == b"old"
+
+
+def test_pi_unavailable_source_dry_run_preserves_same_output_as_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    output = tmp_path / "home"
+    owned_path = output / ".pi/old"
+    apply_pi_reconciliation(
+        output, [PiDesiredFile("plugin1@my-marketplace", Path(".pi/old"), b"old")]
+    )
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            plugins=(PluginConfig(id="plugin1@my-marketplace", scope="user", enabled=True),),
+            conversion=ConversionConfig(targets=("pi",), scope="user"),
+        ),
+    )
+    monkeypatch.setattr(Path, "home", lambda: output)
+    installed = [InstalledPlugin("plugin1@my-marketplace", "1", "user", True, None)]
+    with (
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
+        patch(
+            "ai_config.operations._load_conversion_cache",
+            return_value={"version": 7, "entries": {}, "pi_output_dirs": [str(output)]},
+        ),
+    ):
+        dry_run = sync_target(target, dry_run=True)
+        actual = sync_target(target)
+    assert any(action.action == "preserve_pi_output" for action in dry_run.actions_taken), dry_run
+    assert any("temporarily unavailable" in error for error in dry_run.errors)
+    assert actual.errors == dry_run.errors
+    assert owned_path.read_bytes() == b"old"
 
 
 class TestConversionCache:
@@ -535,6 +614,8 @@ class TestSyncTarget:
         """Conversion falls back to local marketplace source when Claude cache path is stale."""
         plugin_dir = tmp_path / "marketplace" / "plugin1"
         plugin_dir.mkdir(parents=True)
+        (plugin_dir / ".claude-plugin").mkdir()
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text('{"name":"plugin1"}')
         conversion = ConversionConfig(
             enabled=True,
             targets=("pi",),
@@ -604,6 +685,8 @@ class TestSyncTarget:
         marketplace_dir = tmp_path / "marketplace"
         plugin_dir = marketplace_dir / "plugins" / "plugin-source"
         plugin_dir.mkdir(parents=True)
+        (plugin_dir / ".claude-plugin").mkdir()
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text('{"name":"plugin1"}')
         (marketplace_dir / ".claude-plugin").mkdir()
         (marketplace_dir / ".claude-plugin" / "marketplace.json").write_text(
             '{"name":"my-marketplace","plugins":[{"name":"plugin1","source":"./plugins/plugin-source"}]}'

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -126,6 +126,10 @@ def test_pi_sync_target_reconciles_real_emitter_output_at_each_scope(
     source = tmp_path / "source"
     shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
     root = tmp_path / root_suffix
+    native_relative = Path("prompts/native.md")
+    native_source = source / "targets/pi" / native_relative
+    native_source.parent.mkdir(parents=True)
+    native_source.write_text("native Pi prompt")
     monkeypatch.setattr(Path, "home", lambda: root)
     target = TargetConfig(
         type="claude",
@@ -145,7 +149,16 @@ def test_pi_sync_target_reconciles_real_emitter_output_at_each_scope(
     assert result.success, result.errors
     assert {action.action for action in result.actions_taken} == {"create_pi_output"}
     reference_path = skill_path.replace("SKILL.md", "resources/reference.md")
-    expected = {Path(skill_path), Path(reference_path), Path(prompt_path), Path(extension_path)}
+    native_output = (
+        Path(".pi/agent") / native_relative if scope == "user" else Path(".pi") / native_relative
+    )
+    expected = {
+        Path(skill_path),
+        Path(reference_path),
+        Path(prompt_path),
+        Path(extension_path),
+        native_output,
+    }
     ledger = load_pi_ownership(root)
     assert expected <= set(ledger)
     for relative in expected:
@@ -226,6 +239,191 @@ def test_pi_sync_config_removes_renamed_and_disabled_fixture_components(
     assert removed.success, removed.errors
     assert not load_pi_ownership(output)
     assert stale.exists()
+    # The removed reference's parent is deliberately retained only because it has user content.
+    assert old_reference.parent.exists()
+
+
+def test_pi_target_and_plugin_removal_retire_cached_root_after_reconciliation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Pi root tracking survives until its owned files are safely reconciled away."""
+    source = tmp_path / "source"
+    shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    home, output = tmp_path / "home", tmp_path / "output"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    installed = [InstalledPlugin("dev-tools@local", "1", "project", True, str(source))]
+
+    def config(targets: tuple[str, ...], plugins: tuple[PluginConfig, ...]) -> TargetConfig:
+        return TargetConfig(
+            type="claude",
+            config=ClaudeTargetConfig(
+                plugins=plugins,
+                conversion=ConversionConfig(
+                    targets=targets, scope="project", output_dir=str(output)
+                ),
+            ),
+        )
+
+    enabled = PluginConfig(id="dev-tools@local", scope="project", enabled=True)
+    with (
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
+        patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])),
+    ):
+        assert sync_target(config(("pi", "cursor"), (enabled,))).success
+        cache_path = home / ".ai-config/cache/conversion-hashes.json"
+        assert str(output.resolve()) in json.loads(cache_path.read_text())["pi_output_dirs"]
+        removed_target = sync_target(config(("cursor",), (enabled,)))
+        assert removed_target.success, removed_target.errors
+        assert not load_pi_ownership(output)
+        assert str(output.resolve()) not in json.loads(cache_path.read_text())["pi_output_dirs"]
+        # Re-create ownership, then prove a plugin removed entirely from config follows the same path.
+        assert sync_target(config(("pi",), (enabled,))).success
+        removed_plugin = sync_target(config(("pi",), ()))
+
+    assert removed_plugin.success, removed_plugin.errors
+    assert not load_pi_ownership(output)
+    assert str(output.resolve()) not in json.loads(cache_path.read_text())["pi_output_dirs"]
+
+
+def test_pi_dry_run_matches_apply_without_mutating_output_or_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    source = tmp_path / "source"
+    shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    home, output = tmp_path / "home", tmp_path / "output"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            plugins=(PluginConfig(id="dev-tools@local", scope="project", enabled=True),),
+            conversion=ConversionConfig(targets=("pi",), scope="project", output_dir=str(output)),
+        ),
+    )
+    installed = [InstalledPlugin("dev-tools@local", "1", "project", True, str(source))]
+    with (
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
+        patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])),
+    ):
+        assert sync_target(target).success
+        old_prompt = output / ".pi/prompts/dev-tools-commit.md"
+        ledger_path = output / ".ai-config/pi-ownership.json"
+        cache_path = home / ".ai-config/cache/conversion-hashes.json"
+        before = (old_prompt.read_bytes(), ledger_path.read_bytes(), cache_path.read_bytes())
+        (source / "commands/commit.md").unlink()
+        planned = sync_target(target, dry_run=True)
+        assert before == (
+            old_prompt.read_bytes(),
+            ledger_path.read_bytes(),
+            cache_path.read_bytes(),
+        )
+        applied = sync_target(target)
+
+    assert [(a.action, a.target) for a in planned.actions_taken] == [
+        (a.action, a.target) for a in applied.actions_taken
+    ]
+    assert not old_prompt.exists()
+
+
+def test_pi_operation_preserves_local_change_and_rejects_unowned_collision(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    source = tmp_path / "source"
+    shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    output = tmp_path / "output"
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            plugins=(PluginConfig(id="dev-tools@local", scope="project", enabled=True),),
+            conversion=ConversionConfig(targets=("pi",), scope="project", output_dir=str(output)),
+        ),
+    )
+    installed = [InstalledPlugin("dev-tools@local", "1", "project", True, str(source))]
+    with (
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
+        patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])),
+    ):
+        assert sync_target(target).success
+        owned = output / ".pi/prompts/dev-tools-commit.md"
+        owned.write_text("user edit")
+        (source / "commands/commit.md").unlink()
+        preserved = sync_target(target)
+        assert any(action.action == "preserve_pi_output" for action in preserved.actions_taken)
+        assert owned.read_text() == "user edit"
+        assert verify_sync(AIConfig(version=1, targets=(target,)))
+
+    collision_source = tmp_path / "collision-source"
+    shutil.copytree(
+        Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", collision_source
+    )
+    collision_output = tmp_path / "collision-output"
+    collision = collision_output / ".pi/prompts/dev-tools-commit.md"
+    collision.parent.mkdir(parents=True)
+    collision.write_text("user owned")
+    collision_installed = [
+        InstalledPlugin("dev-tools@local", "1", "project", True, str(collision_source))
+    ]
+    collision_target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            plugins=(PluginConfig(id="dev-tools@local", scope="project", enabled=True),),
+            conversion=ConversionConfig(
+                targets=("pi",), scope="project", output_dir=str(collision_output)
+            ),
+        ),
+    )
+    with (
+        patch(
+            "ai_config.operations.claude.list_installed_plugins",
+            return_value=(collision_installed, []),
+        ),
+        patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])),
+    ):
+        failed = sync_target(collision_target)
+
+    assert not failed.success
+    assert any("Unowned Pi output collision" in error for error in failed.errors)
+    assert collision.read_text() == "user owned"
+    assert not load_pi_ownership(collision_output)
+
+
+def test_pi_unavailable_source_recovers_and_converges_on_next_real_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    source = tmp_path / "source"
+    shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    output = tmp_path / "output"
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            plugins=(PluginConfig(id="dev-tools@local", scope="project", enabled=True),),
+            conversion=ConversionConfig(targets=("pi",), scope="project", output_dir=str(output)),
+        ),
+    )
+    available = [InstalledPlugin("dev-tools@local", "1", "project", True, str(source))]
+    unavailable = [InstalledPlugin("dev-tools@local", "1", "project", True, None)]
+    old_prompt = output / ".pi/prompts/dev-tools-commit.md"
+    with patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])):
+        with patch(
+            "ai_config.operations.claude.list_installed_plugins", return_value=(available, [])
+        ):
+            assert sync_target(target).success
+        (source / "commands/commit.md").unlink()
+        with patch(
+            "ai_config.operations.claude.list_installed_plugins", return_value=(unavailable, [])
+        ):
+            blocked = sync_target(target)
+        assert not blocked.success
+        assert old_prompt.exists()
+        with patch(
+            "ai_config.operations.claude.list_installed_plugins", return_value=(available, [])
+        ):
+            recovered = sync_target(target)
+
+    assert recovered.success, recovered.errors
+    assert not old_prompt.exists()
+    assert not load_pi_ownership(output).get(Path(".pi/prompts/dev-tools-commit.md"))
 
 
 def test_noop_pi_output_is_not_a_verification_discrepancy() -> None:

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -285,6 +285,66 @@ def test_pi_target_and_plugin_removal_retire_cached_root_after_reconciliation(
     assert str(output.resolve()) not in json.loads(cache_path.read_text())["pi_output_dirs"]
 
 
+def test_pi_preserved_retired_roots_remain_tracked_until_repeat_cleanup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    source = tmp_path / "source"
+    shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    home, old_root, new_root = tmp_path / "home", tmp_path / "old", tmp_path / "new"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    installed = [InstalledPlugin("dev-tools@local", "1", "project", True, str(source))]
+    plugin = PluginConfig(id="dev-tools@local", scope="project", enabled=True)
+
+    def target(root: Path, targets: tuple[str, ...]) -> TargetConfig:
+        return TargetConfig(
+            type="claude",
+            config=ClaudeTargetConfig(
+                plugins=(plugin,),
+                conversion=ConversionConfig(targets=targets, scope="project", output_dir=str(root)),
+            ),
+        )
+
+    with (
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
+        patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])),
+    ):
+        assert sync_target(target(old_root, ("pi",))).success
+        modified = old_root / ".pi/prompts/dev-tools-commit.md"
+        modified.write_text("local edit")
+        cache_path = home / ".ai-config/cache/conversion-hashes.json"
+        before_dry_run = cache_path.read_bytes()
+
+        dry_run = sync_target(target(old_root, ("cursor",)), dry_run=True)
+        assert any(action.action == "preserve_pi_output" for action in dry_run.actions_taken)
+        assert cache_path.read_bytes() == before_dry_run
+        retired = sync_target(target(old_root, ("cursor",)))
+        assert retired.success, retired.errors
+        assert str(old_root.resolve()) in json.loads(cache_path.read_text())["pi_output_dirs"]
+
+        # A subsequent sync revisits the retained root and prunes it after user cleanup.
+        modified.unlink()
+        cleaned = sync_target(target(old_root, ("cursor",)))
+        assert cleaned.success, cleaned.errors
+        assert not load_pi_ownership(old_root)
+        assert str(old_root.resolve()) not in json.loads(cache_path.read_text())["pi_output_dirs"]
+
+        assert sync_target(target(old_root, ("pi",))).success
+        modified = old_root / ".pi/prompts/dev-tools-commit.md"
+        modified.write_text("local edit")
+        migrated = sync_target(target(new_root, ("pi",)))
+        assert migrated.success, migrated.errors
+        tracked = json.loads(cache_path.read_text())["pi_output_dirs"]
+        assert str(old_root.resolve()) in tracked
+        assert str(new_root.resolve()) in tracked
+
+        modified.unlink()
+        repeated = sync_target(target(new_root, ("pi",)))
+
+    assert repeated.success, repeated.errors
+    assert not load_pi_ownership(old_root)
+    assert json.loads(cache_path.read_text())["pi_output_dirs"] == [str(new_root.resolve())]
+
+
 def test_pi_dry_run_matches_apply_without_mutating_output_or_cache(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -1,7 +1,10 @@
 """Tests for ai_config.operations module."""
 
+import hashlib
 import json
+import shutil
 from pathlib import Path
+from typing import Literal
 from unittest.mock import patch
 
 import pytest
@@ -26,7 +29,7 @@ from ai_config.operations import (
     update_plugins,
     verify_sync,
 )
-from ai_config.pi_ownership import PiDesiredFile, apply_pi_reconciliation
+from ai_config.pi_ownership import PiDesiredFile, apply_pi_reconciliation, load_pi_ownership
 from ai_config.types import (
     AIConfig,
     ClaudeTargetConfig,
@@ -89,6 +92,140 @@ def mock_installed_marketplaces() -> list[InstalledMarketplace]:
             install_location="/path/to/marketplace",
         ),
     ]
+
+
+@pytest.mark.parametrize(
+    ("scope", "root_suffix", "skill_path", "prompt_path", "extension_path"),
+    [
+        (
+            "user",
+            "home",
+            ".pi/agent/skills/dev-tools-nested-skill/SKILL.md",
+            ".pi/agent/prompts/dev-tools-commit.md",
+            ".pi/agent/extensions/dev-tools-hooks.ts",
+        ),
+        (
+            "project",
+            "project",
+            ".pi/skills/dev-tools-nested-skill/SKILL.md",
+            ".pi/prompts/dev-tools-commit.md",
+            ".pi/extensions/dev-tools-hooks.ts",
+        ),
+    ],
+)
+def test_pi_sync_target_reconciles_real_emitter_output_at_each_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    scope: Literal["user", "project"],
+    root_suffix: str,
+    skill_path: str,
+    prompt_path: str,
+    extension_path: str,
+) -> None:
+    """Exercise Pi ownership through sync_target using a complete Claude plugin fixture."""
+    source = tmp_path / "source"
+    shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    root = tmp_path / root_suffix
+    monkeypatch.setattr(Path, "home", lambda: root)
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            plugins=(PluginConfig(id="dev-tools@local", scope=scope, enabled=True),),
+            conversion=ConversionConfig(targets=("pi",), scope=scope, output_dir=str(root)),
+        ),
+    )
+    installed = [InstalledPlugin("dev-tools@local", "1", scope, True, str(source))]
+    with (
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
+        patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])),
+    ):
+        result = sync_target(target)
+        repeat = sync_target(target)
+
+    assert result.success, result.errors
+    assert {action.action for action in result.actions_taken} == {"create_pi_output"}
+    reference_path = skill_path.replace("SKILL.md", "resources/reference.md")
+    expected = {Path(skill_path), Path(reference_path), Path(prompt_path), Path(extension_path)}
+    ledger = load_pi_ownership(root)
+    assert expected <= set(ledger)
+    for relative in expected:
+        owned = ledger[relative]
+        output = root / relative
+        assert output.is_file()
+        assert owned.source_plugin == "dev-tools@local"
+        assert owned.relative_path == relative
+        assert owned.digest == hashlib.sha256(output.read_bytes()).hexdigest()
+        assert owned.executable is bool(output.stat().st_mode & 0o111)
+    assert {action.action for action in repeat.actions_taken} == {"noop_pi_output"}
+
+
+def test_pi_sync_config_removes_renamed_and_disabled_fixture_components(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A real emitter refresh removes obsolete owned paths even while directories remain."""
+    source = tmp_path / "source"
+    shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    output = tmp_path / "output"
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    enabled = PluginConfig(id="dev-tools@local", scope="project", enabled=True)
+    config = AIConfig(
+        version=1,
+        targets=(
+            TargetConfig(
+                type="claude",
+                config=ClaudeTargetConfig(
+                    plugins=(enabled,),
+                    conversion=ConversionConfig(
+                        targets=("pi",), scope="project", output_dir=str(output)
+                    ),
+                ),
+            ),
+        ),
+    )
+    installed = [InstalledPlugin("dev-tools@local", "1", "project", True, str(source))]
+    with (
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
+        patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])),
+        patch(
+            "ai_config.operations.claude.disable_plugin",
+            return_value=CommandResult(success=True, stdout="", stderr="", returncode=0),
+        ),
+    ):
+        assert sync_config(config)["claude"].success
+        old_prompt = output / ".pi/prompts/dev-tools-commit.md"
+        old_reference = output / ".pi/skills/dev-tools-nested-skill/resources/reference.md"
+        stale = old_reference.parent / "manual.txt"
+        stale.write_text("unowned")
+        (source / "commands/commit.md").rename(source / "commands/renamed.md")
+        (source / "skills/category/nested-skill/resources/reference.md").unlink()
+        refreshed = sync_config(config)["claude"]
+        assert refreshed.success, refreshed.errors
+        assert not old_prompt.exists()
+        assert not old_reference.exists()
+        assert stale.read_text() == "unowned"
+        assert (output / ".pi/prompts/dev-tools-renamed.md").is_file()
+        assert any(action.action == "remove_pi_output" for action in refreshed.actions_taken)
+        disabled = AIConfig(
+            version=1,
+            targets=(
+                TargetConfig(
+                    type="claude",
+                    config=ClaudeTargetConfig(
+                        plugins=(
+                            PluginConfig(id="dev-tools@local", scope="project", enabled=False),
+                        ),
+                        conversion=ConversionConfig(
+                            targets=("pi",), scope="project", output_dir=str(output)
+                        ),
+                    ),
+                ),
+            ),
+        )
+        removed = sync_config(disabled)["claude"]
+
+    assert removed.success, removed.errors
+    assert not load_pi_ownership(output)
+    assert stale.exists()
 
 
 def test_noop_pi_output_is_not_a_verification_discrepancy() -> None:

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -34,6 +34,8 @@ from ai_config.types import (
     MarketplaceConfig,
     PluginConfig,
     PluginSource,
+    SyncAction,
+    SyncResult,
     TargetConfig,
 )
 
@@ -90,11 +92,7 @@ def mock_installed_marketplaces() -> list[InstalledMarketplace]:
 
 
 def test_noop_pi_output_is_not_a_verification_discrepancy() -> None:
-    from ai_config.types import SyncAction, SyncResult
-
-    result = SyncResult(
-        actions_taken=[SyncAction("noop_pi_output", ".pi/skill", reason="matches")]
-    )
+    result = SyncResult(actions_taken=[SyncAction("noop_pi_output", ".pi/skill", reason="matches")])
     assert sync_discrepancies({"claude": result}) == []
 
 

--- a/tests/unit/test_pi_ownership.py
+++ b/tests/unit/test_pi_ownership.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import pytest
+
+from ai_config.pi_ownership import (
+    PiDesiredFile,
+    apply_pi_reconciliation,
+    digest_content,
+    load_pi_ownership,
+    plan_pi_reconciliation,
+)
+
+
+def desired(path: str, content: str = "one") -> PiDesiredFile:
+    return PiDesiredFile("demo@local", Path(path), content.encode())
+
+
+def test_create_update_remove_and_noop_are_owned(tmp_path: Path) -> None:
+    assert [a.action for a in apply_pi_reconciliation(tmp_path, [desired(".pi/a")])] == [
+        "create_pi_output"
+    ]
+    assert load_pi_ownership(tmp_path)[Path(".pi/a")].digest == digest_content("one")
+    assert [a.action for a in apply_pi_reconciliation(tmp_path, [desired(".pi/a")])] == [
+        "noop_pi_output"
+    ]
+    assert [a.action for a in apply_pi_reconciliation(tmp_path, [desired(".pi/a", "two")])] == [
+        "update_pi_output"
+    ]
+    assert [a.action for a in apply_pi_reconciliation(tmp_path, [])] == ["remove_pi_output"]
+
+
+def test_unowned_collision_and_local_change_are_preserved(tmp_path: Path) -> None:
+    path = tmp_path / ".pi/a"
+    path.parent.mkdir()
+    path.write_text("manual")
+    with pytest.raises(ValueError, match="Unowned Pi output collision"):
+        plan_pi_reconciliation(tmp_path, [desired(".pi/a")])
+
+
+def test_modified_owned_file_is_not_removed(tmp_path: Path) -> None:
+    apply_pi_reconciliation(tmp_path, [desired(".pi/a")])
+    (tmp_path / ".pi/a").write_text("manual")
+    actions, state = plan_pi_reconciliation(tmp_path, [])
+    assert actions[0].action == "preserve_pi_output"
+    assert Path(".pi/a") in state
+
+
+def test_rejects_traversal_and_symlink(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Invalid Pi owned"):
+        plan_pi_reconciliation(tmp_path, [desired("../outside")])
+    (tmp_path / ".pi").symlink_to(tmp_path)
+    with pytest.raises(ValueError, match="symlink"):
+        plan_pi_reconciliation(tmp_path, [desired(".pi/a")])
+
+
+def test_checkpoint_is_atomic_on_state_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    apply_pi_reconciliation(tmp_path, [desired(".pi/a")])
+    import ai_config.pi_ownership as ownership
+
+    monkeypatch.setattr(
+        ownership, "_write_state", lambda root, entries: (_ for _ in ()).throw(OSError("nope"))
+    )
+    with pytest.raises(OSError, match="nope"):
+        apply_pi_reconciliation(tmp_path, [desired(".pi/a", "two")])
+    # The old checkpoint remains, so a later run detects rather than falsely claiming convergence.
+    assert load_pi_ownership(tmp_path)[Path(".pi/a")].digest == digest_content("one")

--- a/tests/unit/test_pi_ownership.py
+++ b/tests/unit/test_pi_ownership.py
@@ -171,6 +171,66 @@ def test_pending_and_ledger_entries_validate_root_and_temp_collisions_are_preser
     assert reserved.read_text() == "user"
 
 
+@pytest.mark.parametrize("version", [2, 3])
+def test_newer_ledger_versions_require_explicit_executable_mode(
+    tmp_path: Path, version: int
+) -> None:
+    state = tmp_path / ".ai-config/pi-ownership.json"
+    state.parent.mkdir()
+    state.write_text(
+        json.dumps(
+            {
+                "version": version,
+                "root": str(tmp_path.resolve()),
+                "files": [
+                    {"source_plugin": "demo@local", "path": ".pi/a", "digest": digest_content("a")}
+                ],
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="Incomplete Pi ownership entry"):
+        load_pi_ownership(tmp_path)
+
+
+def test_v1_ledger_defaults_missing_executable_mode(tmp_path: Path) -> None:
+    state = tmp_path / ".ai-config/pi-ownership.json"
+    state.parent.mkdir()
+    state.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "root": str(tmp_path.resolve()),
+                "files": [
+                    {"source_plugin": "demo@local", "path": ".pi/a", "digest": digest_content("a")}
+                ],
+            }
+        )
+    )
+    assert not load_pi_ownership(tmp_path)[Path(".pi/a")].executable
+
+
+@pytest.mark.parametrize("base", [Path(".pi"), Path(".pi/agent")])
+def test_removing_owned_files_prunes_empty_parents_but_keeps_pi_boundary_and_user_content(
+    tmp_path: Path, base: Path
+) -> None:
+    owned = [
+        desired((base / "skills/plugin-old/resources/reference.md").as_posix()),
+        desired((base / "prompts/plugin-old.md").as_posix()),
+        desired((base / "extensions/plugin-old/hook.ts").as_posix()),
+    ]
+    apply_pi_reconciliation(tmp_path, owned)
+    user_file = tmp_path / base / "extensions/plugin-old/manual.txt"
+    user_file.write_text("keep")
+    apply_pi_reconciliation(tmp_path, [])
+
+    assert not (tmp_path / base / "skills/plugin-old").exists()
+    assert not (tmp_path / base / "prompts").exists()
+    assert not (tmp_path / base / "extensions/plugin-old/hook.ts").exists()
+    assert user_file.read_text() == "keep"
+    assert (tmp_path / base / "extensions/plugin-old").is_dir()
+    assert (tmp_path / base).is_dir()
+
+
 def test_executable_mode_is_reconciled(tmp_path: Path) -> None:
     executable = PiDesiredFile("demo@local", Path(".pi/run"), b"echo ok", executable=True)
     apply_pi_reconciliation(tmp_path, [executable])

--- a/tests/unit/test_pi_ownership.py
+++ b/tests/unit/test_pi_ownership.py
@@ -10,11 +10,12 @@ from ai_config.pi_ownership import (
     digest_content,
     load_pi_ownership,
     plan_pi_reconciliation,
+    standalone_pi_source_identity,
 )
 
 
-def desired(path: str, content: str = "one") -> PiDesiredFile:
-    return PiDesiredFile("demo@local", Path(path), content.encode())
+def desired(path: str, content: str = "one", owner: str = "demo@local") -> PiDesiredFile:
+    return PiDesiredFile(owner, Path(path), content.encode())
 
 
 def test_create_update_remove_and_noop_are_owned(tmp_path: Path) -> None:
@@ -29,6 +30,29 @@ def test_create_update_remove_and_noop_are_owned(tmp_path: Path) -> None:
         "update_pi_output"
     ]
     assert [a.action for a in apply_pi_reconciliation(tmp_path, [])] == ["remove_pi_output"]
+
+
+def test_ledger_owner_collision_rejects_standalone_and_sync_in_both_directions(
+    tmp_path: Path,
+) -> None:
+    standalone_owner = standalone_pi_source_identity(tmp_path / "standalone", "shared-plugin")
+    sync_owner = "shared-plugin@marketplace"
+    apply_pi_reconciliation(
+        tmp_path,
+        [
+            desired(".pi/standalone-first", owner=standalone_owner),
+            desired(".pi/sync-first", owner=sync_owner),
+        ],
+    )
+
+    for path, existing, requested in (
+        (".pi/standalone-first", standalone_owner, sync_owner),
+        (".pi/sync-first", sync_owner, standalone_owner),
+    ):
+        with pytest.raises(ValueError, match="existing owner.*requested owner") as error:
+            apply_pi_reconciliation(tmp_path, [desired(path, owner=requested)])
+        assert existing in str(error.value)
+        assert requested in str(error.value)
 
 
 def test_unowned_collision_and_local_change_are_preserved(tmp_path: Path) -> None:
@@ -157,7 +181,12 @@ def test_pending_and_ledger_entries_validate_root_and_temp_collisions_are_preser
                 "version": 3,
                 "root": str(tmp_path.resolve()),
                 "files": [
-                    {"source_plugin": "x", "path": ".pi/a", "digest": digest, "executable": False}
+                    {
+                        "source_plugin": "demo@local",
+                        "path": ".pi/a",
+                        "digest": digest,
+                        "executable": False,
+                    }
                 ],
             }
         )

--- a/tests/unit/test_pi_ownership.py
+++ b/tests/unit/test_pi_ownership.py
@@ -53,16 +53,54 @@ def test_rejects_traversal_and_symlink(tmp_path: Path) -> None:
         plan_pi_reconciliation(tmp_path, [desired(".pi/a")])
 
 
-def test_checkpoint_is_atomic_on_state_write_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_rejects_dangling_final_symlinks_for_desired_and_obsolete(tmp_path: Path) -> None:
+    path = tmp_path / ".pi/a"
+    path.parent.mkdir()
+    path.symlink_to(tmp_path / "missing")
+    with pytest.raises(ValueError, match="symlink"):
+        plan_pi_reconciliation(tmp_path, [desired(".pi/a")])
+    path.unlink()
     apply_pi_reconciliation(tmp_path, [desired(".pi/a")])
+    path.unlink()
+    path.symlink_to(tmp_path / "missing")
+    with pytest.raises(ValueError, match="symlink"):
+        plan_pi_reconciliation(tmp_path, [])
+
+
+@pytest.mark.parametrize("before, after", [(None, "one"), ("one", "two"), ("one", None)])
+def test_checkpoint_failure_recovers_on_normal_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    before: str | None,
+    after: str | None,
+) -> None:
     import ai_config.pi_ownership as ownership
 
+    if before is not None:
+        apply_pi_reconciliation(tmp_path, [desired(".pi/a", before)])
+    target = [] if after is None else [desired(".pi/a", after)]
+    original_write_state = ownership._write_state
     monkeypatch.setattr(
         ownership, "_write_state", lambda root, entries: (_ for _ in ()).throw(OSError("nope"))
     )
     with pytest.raises(OSError, match="nope"):
-        apply_pi_reconciliation(tmp_path, [desired(".pi/a", "two")])
-    # The old checkpoint remains, so a later run detects rather than falsely claiming convergence.
-    assert load_pi_ownership(tmp_path)[Path(".pi/a")].digest == digest_content("one")
+        apply_pi_reconciliation(tmp_path, target)
+    assert (tmp_path / ".ai-config/pi-ownership.pending.json").exists()
+    monkeypatch.setattr(ownership, "_write_state", original_write_state)
+    assert apply_pi_reconciliation(tmp_path, target)
+    owned = load_pi_ownership(tmp_path)
+    if after is None:
+        assert Path(".pi/a") not in owned
+        assert not (tmp_path / ".pi/a").exists()
+    else:
+        assert owned[Path(".pi/a")].digest == digest_content(after)
+        assert (tmp_path / ".pi/a").read_text() == after
+
+
+def test_executable_mode_is_reconciled(tmp_path: Path) -> None:
+    executable = PiDesiredFile("demo@local", Path(".pi/run"), b"echo ok", executable=True)
+    apply_pi_reconciliation(tmp_path, [executable])
+    assert (tmp_path / ".pi/run").stat().st_mode & 0o111
+    (tmp_path / ".pi/run").chmod(0o644)
+    assert apply_pi_reconciliation(tmp_path, [executable])[0].action == "update_pi_output"
+    assert (tmp_path / ".pi/run").stat().st_mode & 0o111

--- a/tests/unit/test_pi_ownership.py
+++ b/tests/unit/test_pi_ownership.py
@@ -358,6 +358,11 @@ def test_old_ledger_schema_refuses_cleanup_without_mutation(
     assert json.loads(state.read_text())["version"] == version
 
 
+def test_empty_first_reconciliation_does_not_reserve_a_domain(tmp_path: Path) -> None:
+    apply_pi_reconciliation(tmp_path, [], ownership_domain="sync")
+    assert not (tmp_path / ".ai-config/pi-ownership.json").exists()
+
+
 def test_final_removal_deletes_state_and_allows_new_domain(tmp_path: Path) -> None:
     apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
     apply_pi_reconciliation(tmp_path, [], ownership_domain="sync")

--- a/tests/unit/test_pi_ownership.py
+++ b/tests/unit/test_pi_ownership.py
@@ -1,7 +1,9 @@
+import json
 from pathlib import Path
 
 import pytest
 
+import ai_config.pi_ownership as ownership
 from ai_config.pi_ownership import (
     PiDesiredFile,
     apply_pi_reconciliation,
@@ -74,8 +76,6 @@ def test_checkpoint_failure_recovers_on_normal_retry(
     before: str | None,
     after: str | None,
 ) -> None:
-    import ai_config.pi_ownership as ownership
-
     if before is not None:
         apply_pi_reconciliation(tmp_path, [desired(".pi/a", before)])
     target = [] if after is None else [desired(".pi/a", after)]
@@ -95,6 +95,80 @@ def test_checkpoint_failure_recovers_on_normal_retry(
     else:
         assert owned[Path(".pi/a")].digest == digest_content(after)
         assert (tmp_path / ".pi/a").read_text() == after
+
+
+def test_pending_recovery_preserves_post_crash_user_edits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    apply_pi_reconciliation(tmp_path, [desired(".pi/update", "old"), desired(".pi/remove", "old")])
+    original_write_state = ownership._write_state
+    monkeypatch.setattr(
+        ownership, "_write_state", lambda *_: (_ for _ in ()).throw(OSError("checkpoint"))
+    )
+    with pytest.raises(OSError, match="checkpoint"):
+        apply_pi_reconciliation(
+            tmp_path, [desired(".pi/create", "new"), desired(".pi/update", "new")]
+        )
+    monkeypatch.setattr(ownership, "_write_state", original_write_state)
+    (tmp_path / ".pi/create").write_text("user create")
+    (tmp_path / ".pi/update").write_text("user update")
+    (tmp_path / ".pi/remove").write_text("user remove")
+    with pytest.raises(ValueError, match="diverged"):
+        apply_pi_reconciliation(
+            tmp_path, [desired(".pi/create", "new"), desired(".pi/update", "new")]
+        )
+    with pytest.raises(ValueError, match="diverged"):
+        apply_pi_reconciliation(
+            tmp_path, [desired(".pi/create", "new"), desired(".pi/update", "new")], dry_run=True
+        )
+    assert (tmp_path / ".pi/create").read_text() == "user create"
+    assert (tmp_path / ".pi/update").read_text() == "user update"
+    assert (tmp_path / ".pi/remove").read_text() == "user remove"
+
+
+def test_pending_recovery_rejects_changed_desired_and_unavailable_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_write_state = ownership._write_state
+    monkeypatch.setattr(
+        ownership, "_write_state", lambda *_: (_ for _ in ()).throw(OSError("checkpoint"))
+    )
+    with pytest.raises(OSError):
+        apply_pi_reconciliation(tmp_path, [desired(".pi/a", "one")])
+    monkeypatch.setattr(ownership, "_write_state", original_write_state)
+    with pytest.raises(ValueError, match="does not match"):
+        apply_pi_reconciliation(tmp_path, [desired(".pi/a", "changed")])
+    with pytest.raises(ValueError, match="does not match"):
+        apply_pi_reconciliation(tmp_path, [], retained_sources={"demo@local"})
+
+
+def test_pending_and_ledger_entries_validate_root_and_temp_collisions_are_preserved(
+    tmp_path: Path,
+) -> None:
+    state = tmp_path / ".ai-config/pi-ownership.json"
+    state.parent.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / ".pi").symlink_to(outside)
+    digest = digest_content("one")
+    state.write_text(
+        json.dumps(
+            {
+                "version": 3,
+                "root": str(tmp_path.resolve()),
+                "files": [
+                    {"source_plugin": "x", "path": ".pi/a", "digest": digest, "executable": False}
+                ],
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="symlink"):
+        load_pi_ownership(tmp_path)
+    (tmp_path / ".pi").unlink()
+    reserved = tmp_path / ".ai-config/pi-ownership.json.tmp"
+    reserved.write_text("user")
+    apply_pi_reconciliation(tmp_path, [desired(".pi/a")])
+    assert reserved.read_text() == "user"
 
 
 def test_executable_mode_is_reconciled(tmp_path: Path) -> None:

--- a/tests/unit/test_pi_ownership.py
+++ b/tests/unit/test_pi_ownership.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Literal
 
 import pytest
 
@@ -30,6 +31,23 @@ def test_create_update_remove_and_noop_are_owned(tmp_path: Path) -> None:
         "update_pi_output"
     ]
     assert [a.action for a in apply_pi_reconciliation(tmp_path, [])] == ["remove_pi_output"]
+
+
+def test_current_state_persists_explicit_domain(tmp_path: Path) -> None:
+    apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
+    state = json.loads((tmp_path / ".ai-config/pi-ownership.json").read_text())
+    assert state["version"] == 4
+    assert state["domain"] == "sync"
+
+
+def test_tampered_state_domain_is_rejected(tmp_path: Path) -> None:
+    apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
+    state_path = tmp_path / ".ai-config/pi-ownership.json"
+    state = json.loads(state_path.read_text())
+    state["domain"] = "standalone"
+    state_path.write_text(json.dumps(state))
+    with pytest.raises(ValueError, match="domain does not match entry identity"):
+        apply_pi_reconciliation(tmp_path, [], ownership_domain="standalone")
 
 
 def test_non_overlapping_ownership_domains_reject_in_both_directions(tmp_path: Path) -> None:
@@ -82,8 +100,9 @@ def test_invalid_ledger_source_identity_is_rejected(tmp_path: Path) -> None:
     state.write_text(
         json.dumps(
             {
-                "version": 3,
+                "version": 4,
                 "root": str(tmp_path.resolve()),
+                "domain": "sync",
                 "files": [
                     {
                         "source_plugin": "standalone:bad",
@@ -171,7 +190,7 @@ def test_checkpoint_failure_recovers_on_normal_retry(
     target = [] if after is None else [desired(".pi/a", after)]
     original_write_state = ownership._write_state
     monkeypatch.setattr(
-        ownership, "_write_state", lambda root, entries: (_ for _ in ()).throw(OSError("nope"))
+        ownership, "_write_state", lambda *_: (_ for _ in ()).throw(OSError("nope"))
     )
     with pytest.raises(OSError, match="nope"):
         apply_pi_reconciliation(tmp_path, target)
@@ -185,6 +204,44 @@ def test_checkpoint_failure_recovers_on_normal_retry(
     else:
         assert owned[Path(".pi/a")].digest == digest_content(after)
         assert (tmp_path / ".pi/a").read_text() == after
+
+
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_old_pending_schema_refuses_recovery_without_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: int
+) -> None:
+    original_write_state = ownership._write_state
+    monkeypatch.setattr(
+        ownership, "_write_state", lambda *_: (_ for _ in ()).throw(OSError("checkpoint"))
+    )
+    with pytest.raises(OSError, match="checkpoint"):
+        apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
+    monkeypatch.setattr(ownership, "_write_state", original_write_state)
+    pending_path = tmp_path / ".ai-config/pi-ownership.pending.json"
+    pending = json.loads(pending_path.read_text())
+    pending["version"] = version
+    pending_path.write_text(json.dumps(pending))
+    with pytest.raises(ValueError, match="automatic cleanup is refused.*issue #22"):
+        apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
+    assert (tmp_path / ".pi/a").read_text() == "one"
+
+
+def test_pending_domain_mismatch_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_write_state = ownership._write_state
+    monkeypatch.setattr(
+        ownership, "_write_state", lambda *_: (_ for _ in ()).throw(OSError("checkpoint"))
+    )
+    with pytest.raises(OSError, match="checkpoint"):
+        apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
+    monkeypatch.setattr(ownership, "_write_state", original_write_state)
+    pending_path = tmp_path / ".ai-config/pi-ownership.pending.json"
+    pending = json.loads(pending_path.read_text())
+    pending["domain"] = "standalone"
+    pending_path.write_text(json.dumps(pending))
+    with pytest.raises(ValueError, match="domain does not match entry identity"):
+        apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
 
 
 def test_pending_recovery_preserves_post_crash_user_edits(
@@ -244,8 +301,9 @@ def test_pending_and_ledger_entries_validate_root_and_temp_collisions_are_preser
     state.write_text(
         json.dumps(
             {
-                "version": 3,
+                "version": 4,
                 "root": str(tmp_path.resolve()),
+                "domain": "sync",
                 "files": [
                     {
                         "source_plugin": "demo@local",
@@ -266,11 +324,18 @@ def test_pending_and_ledger_entries_validate_root_and_temp_collisions_are_preser
     assert reserved.read_text() == "user"
 
 
-@pytest.mark.parametrize("version", [2, 3])
-def test_newer_ledger_versions_require_explicit_executable_mode(
-    tmp_path: Path, version: int
+@pytest.mark.parametrize("version", [1, 2, 3])
+@pytest.mark.parametrize(
+    ("domain", "owner"),
+    [("sync", "demo@local"), ("standalone", "standalone:demo:" + "a" * 64)],
+)
+def test_old_ledger_schema_refuses_cleanup_without_mutation(
+    tmp_path: Path, version: int, domain: Literal["sync", "standalone"], owner: str
 ) -> None:
     state = tmp_path / ".ai-config/pi-ownership.json"
+    output = tmp_path / ".pi/a"
+    output.parent.mkdir(parents=True)
+    output.write_text("historical")
     state.parent.mkdir()
     state.write_text(
         json.dumps(
@@ -278,30 +343,48 @@ def test_newer_ledger_versions_require_explicit_executable_mode(
                 "version": version,
                 "root": str(tmp_path.resolve()),
                 "files": [
-                    {"source_plugin": "demo@local", "path": ".pi/a", "digest": digest_content("a")}
+                    {
+                        "source_plugin": owner,
+                        "path": ".pi/a",
+                        "digest": digest_content("historical"),
+                    }
                 ],
             }
         )
     )
-    with pytest.raises(ValueError, match="Incomplete Pi ownership entry"):
-        load_pi_ownership(tmp_path)
+    with pytest.raises(ValueError, match="automatic cleanup is refused.*issue #22"):
+        apply_pi_reconciliation(tmp_path, [], ownership_domain=domain)
+    assert output.read_text() == "historical"
+    assert json.loads(state.read_text())["version"] == version
 
 
-def test_v1_ledger_defaults_missing_executable_mode(tmp_path: Path) -> None:
-    state = tmp_path / ".ai-config/pi-ownership.json"
-    state.parent.mkdir()
-    state.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "root": str(tmp_path.resolve()),
-                "files": [
-                    {"source_plugin": "demo@local", "path": ".pi/a", "digest": digest_content("a")}
-                ],
-            }
-        )
+def test_final_removal_deletes_state_and_allows_new_domain(tmp_path: Path) -> None:
+    apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
+    apply_pi_reconciliation(tmp_path, [], ownership_domain="sync")
+    assert not (tmp_path / ".ai-config/pi-ownership.json").exists()
+    standalone_owner = standalone_pi_source_identity(tmp_path / "plugin", "demo")
+    apply_pi_reconciliation(
+        tmp_path,
+        [desired(".pi/standalone", owner=standalone_owner)],
+        ownership_domain="standalone",
     )
-    assert not load_pi_ownership(tmp_path)[Path(".pi/a")].executable
+
+
+def test_final_removal_checkpoint_failure_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    apply_pi_reconciliation(tmp_path, [desired(".pi/a")], ownership_domain="sync")
+    original_write_state = ownership._write_state
+    monkeypatch.setattr(
+        ownership, "_write_state", lambda *_: (_ for _ in ()).throw(OSError("checkpoint"))
+    )
+    with pytest.raises(OSError, match="checkpoint"):
+        apply_pi_reconciliation(tmp_path, [], ownership_domain="sync")
+    assert (tmp_path / ".ai-config/pi-ownership.pending.json").exists()
+    monkeypatch.setattr(ownership, "_write_state", original_write_state)
+    apply_pi_reconciliation(tmp_path, [], ownership_domain="sync")
+    assert not (tmp_path / ".ai-config/pi-ownership.json").exists()
+    assert not (tmp_path / ".ai-config/pi-ownership.pending.json").exists()
 
 
 @pytest.mark.parametrize("base", [Path(".pi"), Path(".pi/agent")])

--- a/tests/unit/test_pi_ownership.py
+++ b/tests/unit/test_pi_ownership.py
@@ -32,22 +32,88 @@ def test_create_update_remove_and_noop_are_owned(tmp_path: Path) -> None:
     assert [a.action for a in apply_pi_reconciliation(tmp_path, [])] == ["remove_pi_output"]
 
 
-def test_ledger_owner_collision_rejects_standalone_and_sync_in_both_directions(
-    tmp_path: Path,
-) -> None:
-    standalone_owner = standalone_pi_source_identity(tmp_path / "standalone", "shared-plugin")
-    sync_owner = "shared-plugin@marketplace"
+def test_non_overlapping_ownership_domains_reject_in_both_directions(tmp_path: Path) -> None:
+    standalone_owner = standalone_pi_source_identity(tmp_path / "plugin", "standalone")
+    apply_pi_reconciliation(
+        tmp_path,
+        [desired(".pi/standalone", owner=standalone_owner)],
+        ownership_domain="standalone",
+    )
+    with pytest.raises(ValueError, match="ownership domain conflict.*separate root"):
+        apply_pi_reconciliation(
+            tmp_path,
+            [desired(".pi/sync", owner="sync@local")],
+            ownership_domain="sync",
+        )
+
+    other = tmp_path / "other"
+    apply_pi_reconciliation(
+        other, [desired(".pi/sync", owner="sync@local")], ownership_domain="sync"
+    )
+    with pytest.raises(ValueError, match="ownership domain conflict.*separate root"):
+        apply_pi_reconciliation(
+            other,
+            [desired(".pi/standalone", owner=standalone_owner)],
+            ownership_domain="standalone",
+        )
+
+
+def test_same_ownership_domain_allows_multiple_standalone_sources(tmp_path: Path) -> None:
+    first = standalone_pi_source_identity(tmp_path / "first", "first")
+    second = standalone_pi_source_identity(tmp_path / "second", "second")
+    apply_pi_reconciliation(
+        tmp_path, [desired(".pi/first", owner=first)], ownership_domain="standalone"
+    )
+    apply_pi_reconciliation(
+        tmp_path,
+        [desired(".pi/second", owner=second)],
+        retained_sources={first},
+        ownership_domain="standalone",
+    )
+    assert {entry.source_plugin for entry in load_pi_ownership(tmp_path).values()} == {
+        first,
+        second,
+    }
+
+
+def test_invalid_ledger_source_identity_is_rejected(tmp_path: Path) -> None:
+    state = tmp_path / ".ai-config/pi-ownership.json"
+    state.parent.mkdir()
+    state.write_text(
+        json.dumps(
+            {
+                "version": 3,
+                "root": str(tmp_path.resolve()),
+                "files": [
+                    {
+                        "source_plugin": "standalone:bad",
+                        "path": ".pi/a",
+                        "digest": digest_content("a"),
+                        "executable": False,
+                    }
+                ],
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="Invalid standalone Pi ownership identity"):
+        load_pi_ownership(tmp_path)
+
+
+def test_ledger_owner_collision_rejects_same_domain_owner_reassignment(tmp_path: Path) -> None:
+    first_owner = "first@marketplace"
+    second_owner = "second@marketplace"
     apply_pi_reconciliation(
         tmp_path,
         [
-            desired(".pi/standalone-first", owner=standalone_owner),
-            desired(".pi/sync-first", owner=sync_owner),
+            desired(".pi/first", owner=first_owner),
+            desired(".pi/second", owner=second_owner),
         ],
+        ownership_domain="sync",
     )
 
     for path, existing, requested in (
-        (".pi/standalone-first", standalone_owner, sync_owner),
-        (".pi/sync-first", sync_owner, standalone_owner),
+        (".pi/first", first_owner, second_owner),
+        (".pi/second", second_owner, first_owner),
     ):
         with pytest.raises(ValueError, match="existing owner.*requested owner") as error:
             apply_pi_reconciliation(tmp_path, [desired(path, owner=requested)])


### PR DESCRIPTION
## Why

Pi conversion wrote loose runtime-discoverable files without retaining ownership. Renaming, disabling, or removing a source component could therefore leave stale skills, prompts, extensions, and target-native files behind.

## What changed

- Add a Pi-specific ownership ledger containing the validated output root, source plugin identity, relative path, content digest, and executable mode.
- Reconcile desired output across create, update, removal, preservation, and collision cases for user and project scopes.
- Use a durable pending transaction with pre/post disk state so interrupted filesystem or checkpoint work can retry without overwriting later user edits.
- Fail closed for unowned collisions, traversal, symlinks, malformed state, duplicate paths, unavailable sources, and changed recovery inputs.
- Keep dry-run, sync/status verification, and JSON reporting aligned. Standalone Pi conversion uses the same ledger while retaining other source projections; other targets keep their existing conversion behavior.
- Prune only empty ancestors of removed owned files. Historical unowned output stays untouched and continues to point to issue #22.

## Proof

- 769 unit tests passed, including real Pi emitter fixtures for skills, support files, prompts, extensions, and target-native files in both scopes.
- 8 non-Docker integration tests passed.
- Ruff, formatting, and changed-source typing passed. Repository-wide typing retains 16 existing diagnostics outside this change.
- Independent final review found no unresolved P0-P2 issue.
- GitHub real-tool E2E and the latest Codex package probe passed.

Factory session: `6a1f3daa-1d01-59ce-9bd0-f63f0c07b96f`
Resume: `pi --session 6a1f3daa-1d01-59ce-9bd0-f63f0c07b96f`

Fixes #23
