### PR TITLE
Bootstrap complete ai-config project context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,12 @@ Cross-cutting docs in `ai_agent_docs/`:
 - `ai_agent_docs/adding-a-target.md` — Step-by-step guide for adding a new conversion target
 - `ai_agent_docs/target-compatibility-baseline.md` — Current target-runtime assumptions, version baseline, and validation probes
 
+Architecture context in `docs/`:
+- `SPEC.md` — Normative current-truth correctness envelope
+- `docs/explanation/architecture.md` — Current boundaries, flows, and ownership
+- `docs/explanation/project-evolution.md` — Historical phases and retained tradeoffs
+- `docs/adr/` — Accepted architectural decisions and rationale
+
 ## Gotchas
 
 - **Claude Code reloads plugins at session start** — after `ai-config sync`, restart Claude Code (use `claude --resume` to continue)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Canonical correctness-envelope specification, current architecture and project-evolution explanations, and five historical ADRs for source format, IR conversion, Codex packages, ownership-safe cleanup, and observe-plan-apply sync.
+
 ## [0.6.2] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -182,9 +182,13 @@ ai-config doctor --target all ./output-dir
 
 ## Further reading
 
+- [Specification](SPEC.md) — normative current-truth correctness envelope
 - [Commands](docs/commands.md) — complete CLI reference
 - [Configuration](docs/config.md) — config schema, path resolution, scopes, and examples
 - [Conversion](docs/conversion.md) — target mappings, dry runs, reports, and validation
+- [Architecture](docs/explanation/architecture.md) — system boundaries, flows, and ownership
+- [Project evolution](docs/explanation/project-evolution.md) — historical phases and retained tradeoffs
+- [Architecture decisions](docs/adr/001-use-claude-plugins-as-the-canonical-source.md) — lasting choices and rationale
 
 ## License
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,564 +1,109 @@
-# SPEC.md — Claude Code Plugin Conversion + Validation for Claude Code, Codex, Cursor, OpenCode, Pi
-
-## 1) Purpose
-
-Create a tool that:
-1. Ingests a Claude Code plugin (the Claude "plugin bundle" format).
-2. Normalizes it into a Pydantic-based Intermediate Representation (IR).
-3. Emits equivalent artifacts to one or more targets:
-   - Claude Code
-   - OpenAI Codex (Codex CLI / IDE extension surfaces)
-   - Cursor
-   - OpenCode
-   - Pi
-4. Provides a post-conversion validator that can verify (via CLI where available, otherwise via TUI/UX steps) that each exported component is installed and functional.
-
-This spec is intentionally explicit about:
-- Component taxonomy
-- On-disk locations and scope layers (only when supported by primary sources)
-- What can be validated automatically vs what requires interactive confirmation
-
----
-
-## 2) Design constraints and principles
-
-### 2.1 Reliability over "perfect equivalence"
-
-Some primitives exist in one tool but not another (notably hooks). The converter must support degradation policies and produce a report that states exactly what was mapped, emulated, or dropped.
-
-### 2.2 Target surfaces vary (bundle vs split features)
-
-Claude Code plugins are a single installable bundle with multiple component types. Other tools typically split functionality across:
-- skills directories
-- command/prompt directories
-- hooks/event systems (if present)
-- MCP config files (TOML/JSON/etc.)
-
-Claude Code plugin system details and component schemas are defined in the official Plugins Reference and "Create plugins" docs.
-
----
-
-## 3) Research: component model and supported target surfaces
-
-### 3.1 Claude Code (source format)
-
-#### 3.1.1 Plugin layout
-Claude plugins are defined by plugin.json and can include component directories at the plugin root (e.g., skills/, commands/, agents/, hooks/, plus MCP/LSP definitions), with an explicit warning that only plugin.json goes inside .claude-plugin/ and component directories live at the plugin root.
-
-#### 3.1.2 What components Claude plugins can contain
-Claude plugin components include:
-- Skills
-- Commands
-- Hooks
-- Agents
-- MCP servers
-- LSP servers
-(all defined by schemas and documented in the Plugins Reference).
-
-#### 3.1.3 Debug and validation tooling
-Claude provides developer tooling in the plugin system:
-- `claude plugin validate` (and UI equivalents referenced in plugin documentation)
-- `claude --debug` to see plugin loading, registration, and initialization details (including MCP initialization per plugin debug expectations)
-
-Note: This spec does not assume a "list installed plugins" CLI exists as a stable command, because the authoritative plugin reference emphasizes validate/debug/installation surfaces rather than a guaranteed enumeration command.
-
----
-
-### 3.2 OpenAI Codex (Codex CLI / IDE surfaces)
-
-#### 3.2.1 Plugin packages and marketplaces
-Codex supports installable plugin packages containing a `.codex-plugin/plugin.json` manifest and package-local skills, hooks, and MCP servers. Local marketplaces are registered and packages are installed, listed, and removed through `codex plugin` commands.
-
-#### 3.2.2 Agent Skills (first-class)
-Codex package skills are reusable instruction/resource bundles. Claude commands map to package skills; Claude-only argument substitution is reported as degraded rather than emitted as a legacy custom prompt.
-
-#### 3.2.3 Ownership
-ai-config owns generated package sources, local marketplace sources, and its ownership record. Codex owns installed cache, enablement, and shared configuration. The converter does not write loose `.codex` skills, prompts, hooks, or MCP tables.
-
----
-
-### 3.3 Cursor
-
-#### 3.3.1 Commands
-Cursor supports project commands by creating a `.cursor/commands` directory with Markdown files.
-
-#### 3.3.2 Agent Skills
-Cursor supports "Agent Skills" as portable packages that can include instructions and executable elements; this is documented as a first-class "skills" feature.
-
-#### 3.3.3 Hooks
-Cursor supports hooks as external processes that interact with the agent loop (stdio + JSON protocol) and documents the hooks system.
-
----
-
-### 3.4 OpenCode
-
-#### 3.4.1 Agent Skills
-OpenCode supports Agent Skills via SKILL.md definitions and a native skill tool that loads them on demand.
-
-#### 3.4.2 Config directory override
-OpenCode supports overriding the config directory via `OPENCODE_CONFIG_DIR` and searches that directory for agents/commands/modes/plugins similarly to `.opencode`.
-
-#### 3.4.3 Native skills provenance
-OpenCode's skills support is explicitly described as native (graduated from a plugin into core support), providing confidence that "skills" are a stable surface.
-
-Note: This spec does not hardcode an "official skill listing debug command" for OpenCode because the authoritative docs shown here focus on skills behavior and configuration, not a guaranteed `opencode debug skill` CLI surface.
-
----
-
-## 4) Canonical component taxonomy (IR-level)
-
-The converter normalizes a Claude plugin into these component kinds:
-- Skill
-- Command
-- Hook
-- MCP server
-- Agent
-- LSP server
-- Arbitrary files (pass-through payload)
-
-This matches Claude's plugin reference categories for plugin contents.
-
----
-
-## 5) Intermediate Representation (Pydantic schema)
-
-### 5.1 Pydantic types (authoritative schema for the tool)
-
-```python
-from __future__ import annotations
-
-from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
-
-from pydantic import BaseModel, Field
-
-
-class TargetTool(str, Enum):
-    CLAUDE = "claude"
-    CODEX = "codex"
-    CURSOR = "cursor"
-    OPENCODE = "opencode"
-    PI = "pi"
-
-
-class InstallScope(str, Enum):
-    USER = "user"
-    PROJECT = "project"
-    LOCAL = "local"  # uncommitted machine-local where supported
-
-
-class ComponentKind(str, Enum):
-    SKILL = "skill"
-    COMMAND = "command"
-    HOOK = "hook"
-    MCP_SERVER = "mcp_server"
-    AGENT = "agent"
-    LSP_SERVER = "lsp_server"
-    FILE = "file"
-
-
-class MappingStatus(str, Enum):
-    NATIVE = "native"
-    TRANSFORM = "transform"
-    EMULATE = "emulate"
-    FALLBACK = "fallback"
-    UNSUPPORTED = "unsupported"
-
-
-class Severity(str, Enum):
-    INFO = "info"
-    WARN = "warn"
-    ERROR = "error"
-
-
-class EvidenceType(str, Enum):
-    CLI = "cli"
-    TUI = "tui"
-    FILESYSTEM = "filesystem"
-    LOG = "log"
-
-
-class Diagnostic(BaseModel):
-    severity: Severity
-    message: str
-    component_ref: Optional[str] = None  # e.g. "skill:my-skill"
-
-
-class PluginIdentity(BaseModel):
-    plugin_id: str = Field(..., description="Stable ID for namespacing")
-    name: str
-    version: Optional[str] = None
-    description: Optional[str] = None
-
-
-class TextFile(BaseModel):
-    relpath: str
-    content: str
-    executable: bool = False
-
-
-class BinaryFile(BaseModel):
-    relpath: str
-    content_b64: str
-    executable: bool = False
-
-
-AnyFile = Union[TextFile, BinaryFile]
-
-
-class Skill(BaseModel):
-    kind: Literal[ComponentKind.SKILL] = ComponentKind.SKILL
-    name: str
-    scope_hint: InstallScope = InstallScope.USER
-    entrypoint: str = "SKILL.md"
-    files: List[AnyFile] = Field(default_factory=list)
-
-
-class Command(BaseModel):
-    kind: Literal[ComponentKind.COMMAND] = ComponentKind.COMMAND
-    name: str
-    scope_hint: InstallScope = InstallScope.USER
-    markdown: str
-
-
-class HookHandlerType(str, Enum):
-    COMMAND = "command"
-    PROMPT = "prompt"
-
-
-class HookHandler(BaseModel):
-    type: HookHandlerType
-    command: Optional[str] = None
-    prompt: Optional[str] = None
-    timeout_sec: Optional[int] = None
-
-
-class HookEvent(BaseModel):
-    # Canonical event names follow Claude's hook event taxonomy.
-    name: str
-    matcher: Optional[str] = None
-    handlers: List[HookHandler] = Field(default_factory=list)
-
-
-class Hook(BaseModel):
-    kind: Literal[ComponentKind.HOOK] = ComponentKind.HOOK
-    scope_hint: InstallScope = InstallScope.USER
-    events: List[HookEvent] = Field(default_factory=list)
-
-
-class McpTransport(str, Enum):
-    STDIO = "stdio"
-    HTTP = "http"
-    STREAMING_HTTP = "streaming_http"
-
-
-class McpServer(BaseModel):
-    kind: Literal[ComponentKind.MCP_SERVER] = ComponentKind.MCP_SERVER
-    name: str
-    scope_hint: InstallScope = InstallScope.USER
-    transport: McpTransport
-    command: Optional[str] = None
-    args: List[str] = Field(default_factory=list)
-    url: Optional[str] = None
-    env: Dict[str, str] = Field(default_factory=dict)
-    cwd: Optional[str] = None
-
-
-class Agent(BaseModel):
-    kind: Literal[ComponentKind.AGENT] = ComponentKind.AGENT
-    name: str
-    scope_hint: InstallScope = InstallScope.USER
-    markdown: str
-
-
-class LspServer(BaseModel):
-    kind: Literal[ComponentKind.LSP_SERVER] = ComponentKind.LSP_SERVER
-    name: str
-    scope_hint: InstallScope = InstallScope.USER
-    config: Dict[str, Any] = Field(default_factory=dict)
-
-
-Component = Union[Skill, Command, Hook, McpServer, Agent, LspServer]
-
-
-class PluginIR(BaseModel):
-    identity: PluginIdentity
-    components: List[Component] = Field(default_factory=list)
-    diagnostics: List[Diagnostic] = Field(default_factory=list)
+# ai-config specification
+
+## Summary
+
+ai-config makes AI coding-tool setup reproducible from one versioned YAML
+configuration. It reconciles Claude Code marketplaces and plugins, and it can
+convert Claude plugin bundles for Codex, Cursor, OpenCode, and Pi without
+presenting lossy mappings as exact equivalence.
+
+## Goals / Non-Goals
+
+Goals:
+
+- Reconcile configured Claude marketplace and plugin state predictably.
+- Let one Claude plugin source produce independently validated target outputs.
+- Preview mutations, preserve evidence about degraded mappings, and clean up
+  generated state only when ownership is established.
+- Keep target-runtime compatibility explicit and testable.
+
+Non-goals:
+
+- Define a universal plugin standard or support arbitrary source formats.
+- Promise feature parity across tools with different component models.
+- Own unrelated target-tool state or silently adopt historical generated files.
+- Replace the target CLIs that own installation, enablement, or runtime behavior.
+
+## Requirements
+
+- Configuration discovery MUST prefer an explicit `--config` path, then
+  project-local `.ai-config/config.yaml` or `.yml`, then the corresponding
+  user-level files under `~/.ai-config/`.
+- `sync` MUST treat the selected version 1 configuration as desired state and
+  MUST NOT silently convert observed runtime state into configuration.
+- Normal dry-run and apply MUST consume the same ordered `SyncPlan`; planning
+  MUST NOT write files, clear caches, delete output, or invoke state-changing
+  target commands.
+- Apply MUST verify that the observed state and conversion inputs still match
+  the plan before mutation.
+- Conversion MUST parse Claude plugin bundles into one target-independent
+  `PluginIR`, and each emitter MUST produce an independent `EmitResult` without
+  mutating the shared IR.
+- Conversion MUST use `native`, `transform`, `emulate`, `fallback`, and
+  `unsupported` mappings plus diagnostics to describe fidelity; a written file
+  MUST NOT be presented as proof of semantic equivalence.
+- Target-native files under `targets/<target>/` MUST override generated files
+  only inside the selected target output boundary.
+- Codex package removal and Pi file cleanup MUST require durable ownership
+  evidence, preserve unrelated state, and reject traversal, symlink, and
+  ownership-collision ambiguity. Pi cleanup MUST additionally preserve locally
+  modified owned files by content digest.
+- Cache and ownership checkpoints MUST be committed only after their authorized
+  actions succeed; reports MUST distinguish completed, failed, planned, and
+  no-op actions when later phases fail.
+- Operators SHOULD use `--dry-run` as the inspection path before a mutating
+  sync or standalone conversion.
+- Callers MAY select any supported conversion subset from Codex, Cursor,
+  OpenCode, and Pi.
+
+## Interfaces & Contracts
+
+- `ai-config init` creates configuration interactively or through its supported
+  non-interactive inputs.
+- `ai-config sync` reconciles configured state; `sync --dry-run` is the
+  mutation-free preview boundary.
+- `ai-config status`, `update`, and `watch` inspect drift, refresh installed
+  plugins, and re-run reconciliation after relevant changes.
+- `ai-config convert <plugin>` parses one Claude plugin and emits selected target
+  formats; `--dry-run` previews paths and mappings without writing.
+- `ai-config doctor` validates configured plugin health, while
+  `doctor --target <target> <output>` validates converted output.
+- The version 1 YAML schema accepts Claude marketplaces/plugins plus optional
+  conversion settings for `codex`, `cursor`, `opencode`, and `pi`.
+- `.claude-plugin/plugin.json` is the canonical source manifest boundary;
+  `PluginIR` is the internal conversion boundary; `EmitResult` and lifecycle
+  plans are target-specific output boundaries.
+- Codex installation is delegated to the Codex plugin CLI. Cursor and OpenCode
+  receive path-contained files. Pi receives project `.pi/` or user
+  `~/.pi/agent/` files governed by ai-config's Pi ownership ledger.
+
+## Invariants
+
+- Desired, observed, planned, applied, and reported state remain distinct.
+- A failed or unavailable source cannot authorize cleanup of previously owned
+  output merely because it is absent from the current observation.
+- Generated identities and paths are normalized deterministically and remain
+  contained beneath their validated output roots.
+- Unowned collisions fail closed; historical unowned output remains a human
+  cleanup decision.
+- Conversion diagnostics accumulate instead of hiding unsupported or degraded
+  behavior behind a successful file write.
+- Target-specific lifecycle code may validate and execute its own actions but
+  cannot bypass the materialized sync plan as the authorization boundary.
+
+## Acceptance
+
+Current behavior is accepted when all of the following pass:
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/
+uv run ty check src/
+uv run pytest tests/ -q
+uv run mkdocs build --strict
 ```
 
-### 5.2 Canonicalization rules
-- Treat Claude's SKILL.md-based skills as the canonical "skill" primitive across all targets that support skills (Codex/Cursor/OpenCode all document skills).
-- Use Claude hook event names as canonical in IR (Claude defines these in the plugin reference); targets may translate to their event systems where feasible.
-- Preserve original file trees in skills whenever possible; do not flatten unless a target forces it (e.g., legacy prompts).
-
----
-
-## 6) Mapping matrix (component × target × status)
-
-Statuses:
-- **native**: direct representation exists
-- **transform**: config/schema conversion required
-- **emulate**: implement as a plugin/hook wrapper mechanism
-- **fallback**: degrade to a prompt/command/flattened file
-- **unsupported**: no documented equivalent in target surfaces
-
-| Component | Claude Code | Codex | Cursor | OpenCode | Pi |
-|-----------|-------------|-------|--------|----------|----|
-| Skill | native (Claude plugin skills) | native (package-local Agent Skill) | native (Agent Skills) | native (Agent Skills + skill tool) | native (Agent Skills) |
-| Command | native (plugin commands exist, though skills are recommended) | transform/fallback (package skill; degraded when Claude argument substitution is used) | native (.cursor/commands) | native (OpenCode supports markdown-backed commands in .opencode/commands/ and ~/.config/opencode/commands/; optionally also supports JSON-defined commands in config). | transform (Pi prompt templates) |
-| Hook | native (Claude hooks in plugin system) | transform (supported command hooks in the package hooks file) | native (Cursor hooks) | emulate (OpenCode has plugins; implement hook-like behavior via plugins if needed, but this spec does not claim a specific hook event API beyond what OpenCode documents as plugin/config extensibility) | emulate (generated TypeScript extension) |
-| MCP server | native (Claude plugin MCP support) | transform (package manifest `mcpServers`) | transform (Cursor supports MCP) | native/transform (OpenCode supports MCP; config directory overridable) | unsupported |
-| Agent | native (Claude plugin agents) | unsupported (no documented matching file schema in cited sources) | unsupported | unsupported | unsupported |
-| LSP | native (Claude plugin LSP servers) | unsupported | unsupported | transform (OpenCode supports LSP configuration via the lsp section in opencode.json, including custom LSP servers by command + extensions). | unsupported |
-
----
-
-## 7) Emission rules (what the converter writes)
-
-### 7.1 Core output conventions
-- Use a deterministic namespace prefix derived from `plugin_id` for all emitted assets to prevent collisions.
-- Maintain an install manifest recording every file write so uninstall is deterministic (especially for targets without a bundle lifecycle).
-
-### 7.2 Skill emission
-- Prefer skills as the universal export mechanism when possible (Codex recommends skills for reusable prompts; OpenCode and Cursor also support skills).
-- Preserve the skill directory file tree; only transform metadata if the target requires additional frontmatter keys (not assumed by this spec unless a primary source demands it).
-
-### 7.3 Command emission
-- **Cursor**: emit project commands under `.cursor/commands/<plugin_id>-<command>.md`.
-- **Codex**: always emit commands as package-local skills and report Claude-only argument substitution as degraded.
-- **OpenCode**: emit markdown commands under `.opencode/commands/<plugin_id>-<command>.md` (project scope) or `~/.config/opencode/commands/` (user scope). Use YAML frontmatter for metadata when needed (description/agent/model). Alternatively (optional), emit JSON-defined commands into opencode.json under command.
-
-### 7.4 Hooks emission
-- **Claude**: emit hooks as Claude plugin hooks per schema.
-- **Cursor**: emit Cursor hooks (implementation requires Cursor hook configuration schema; Cursor documents the hooks subsystem but this spec does not hardcode file formats beyond what's explicitly documented).
-- **Codex**: emit supported command hooks into the package and rewrite `${CLAUDE_PLUGIN_ROOT}` to `${PLUGIN_ROOT}`; copy referenced support files and diagnose unsupported or unsafe handlers.
-- **Pi**: emit supported command hooks as a TypeScript extension under `.pi/extensions/` or `.pi/agent/extensions/`; diagnose unsupported events and non-command handlers.
-
-### 7.5 MCP emission
-- Convert Claude plugin MCP entries to each target's MCP configuration surface.
-- For Codex, emit `mcpServers` in the package manifest, rewrite plugin-root references, and include referenced local support files.
-- For OpenCode, allow `OPENCODE_CONFIG_DIR` support: emit into the selected config directory, so validation can be done against that directory.
-
-### 7.6 LSP emission (OpenCode)
-
-Convert Claude LSP entries to OpenCode's `opencode.json` lsp map. For each server, set `command` and `extensions`; carry over environment variables and initialization options where representable. OpenCode supports custom LSP servers via `lsp.<name>.command` and `lsp.<name>.extensions`.
-
----
-
-## 8) Validation: run-after-conversion checks
-
-### 8.1 Validator architecture
-
-The tool emits a set of `ValidationSteps`, then runs them to produce a `ValidationReport`.
-- Prefer CLI checks.
-- Use TUI/UX checks only where CLI enumeration is not documented.
-- Each step must record:
-  - command or UI steps
-  - expected output (substring/regex)
-  - captured evidence (stdout/stderr/screenshot/text capture)
-  - pass/fail/skip
-
-### 8.2 Validator Pydantic models
-
-```python
-from enum import Enum
-from typing import Dict, List, Optional
-from pydantic import BaseModel, Field
-
-class CheckResult(str, Enum):
-    PASS = "pass"
-    FAIL = "fail"
-    SKIP = "skip"
-
-class ValidationStep(BaseModel):
-    id: str
-    target: TargetTool
-    scope: InstallScope
-    component_kind: ComponentKind
-    component_name: Optional[str] = None
-    evidence_type: EvidenceType
-    command: Optional[str] = None
-    tui_steps: Optional[List[str]] = None
-    expected: str
-    notes: Optional[str] = None
-
-class ValidationEvidence(BaseModel):
-    captured_stdout: Optional[str] = None
-    captured_stderr: Optional[str] = None
-    files_checked: List[str] = Field(default_factory=list)
-    extra: Dict[str, str] = Field(default_factory=dict)
-
-class ValidationRecord(BaseModel):
-    step: ValidationStep
-    result: CheckResult
-    evidence: Optional[ValidationEvidence] = None
-    diagnostics: List[Diagnostic] = Field(default_factory=list)
-
-class ValidationReport(BaseModel):
-    plugin: PluginIdentity
-    records: List[ValidationRecord] = Field(default_factory=list)
-    summary: Dict[str, int] = Field(default_factory=dict)
-```
-
----
-
-## 9) Concrete validation steps (only those supported by cited sources)
-
-### 9.1 Claude Code validation steps
-
-**C1 — Validate plugin manifest**
-- Evidence: CLI
-- Command: `claude plugin validate <path-to-plugin>`
-- Expect: exit 0 / "valid"
-- Source: Claude plugin reference includes developer tools and validate flows.
-
-**C2 — Load plugin with debug and verify registration**
-- Evidence: CLI/LOG
-- Command: `claude --debug ...` (categories as needed)
-- Expect: debug indicates plugin loaded and components registered (including MCP initialization details)
-- Source: plugin reference describes --debug output for plugin loading/initialization.
-
-**C3 — Skills/commands discoverable (interactive smoke test)**
-- Evidence: TUI
-- Steps:
-  1. Start Claude Code interactive session
-  2. Type `/` and verify plugin skill/command appears
-  3. Invoke `/skill-name` (or command)
-- Expect: selection shows component; invocation works
-- Source: plugin reference states skills/commands are discovered when plugin is installed.
-
-**C4 — Hooks fire (debug-driven)**
-- Evidence: LOG
-- Steps:
-  1. Start with `claude --debug ...`
-  2. Trigger a tool-use path that the hook matches
-- Expect: hook event lines in debug/log output
-- Source: hooks are a defined plugin component and part of plugin debug surface.
-
-### 9.2 Codex validation steps
-
-**X1 — Package and marketplace validate**
-- Evidence: FILESYSTEM + CLI
-- Steps:
-  1. Run `ai-config doctor --target codex <output-dir>`.
-  2. Register the generated local marketplace with `codex plugin marketplace add`.
-- Expect: package paths and manifests validate; marketplace appears in JSON listing.
-
-**X2 — Plugin lifecycle converges**
-- Evidence: CLI
-- Steps:
-  1. Install the generated selector with `codex plugin add`.
-  2. Verify enabled state with `codex plugin list --json`.
-  3. Re-sync, update source, re-sync, then remove source and re-sync.
-- Expect: install, idempotence, refresh, and removal succeed without duplicate or unrelated state changes.
-
-**X3 — Skill discovery and package ingestion**
-- Evidence: CLI
-- Steps:
-  1. Run auth-free `codex debug prompt-input` in an isolated home.
-  2. Verify package skills when enabled, absent when disabled, and restored when re-enabled.
-  3. Verify hooks in the installed cache and MCP servers through `codex mcp list`.
-- Expect: package components are visible only while the generated plugin is enabled.
-
-**X4 — Shared config remains valid**
-- Evidence: CLI
-- Steps:
-  1. Seed unrelated settings, marketplace, and plugin state.
-  2. Complete the managed lifecycle.
-  3. Run `codex --strict-config doctor --json`.
-- Expect: unrelated state remains and strict configuration loading succeeds.
-
-### 9.3 Cursor validation steps
-
-**U1 — Commands discoverable**
-- Evidence: FILESYSTEM + TUI
-- Steps:
-  1. Ensure `.cursor/commands/<name>.md` exists
-  2. In Cursor agent/chat, type `/` to view commands
-- Expect: command appears
-- Source: Cursor commands doc specifies `.cursor/commands` and Markdown file format.
-
-**U2 — Skills available**
-- Evidence: TUI
-- Steps:
-  1. Install/export skills into Cursor's supported skills surface
-  2. Use Cursor's documented skills UX to invoke skill
-- Expect: skill works
-- Source: Cursor Agent Skills docs.
-
-**U3 — Hooks operational**
-- Evidence: LOG/TUI
-- Steps:
-  1. Configure hook per Cursor hooks docs
-  2. Trigger matching agent-loop activity
-- Expect: hook executes as expected
-- Source: Cursor hooks docs.
-
-### 9.4 OpenCode validation steps
-
-**O1 — Skills functional (runtime smoke test)**
-- Evidence: TUI
-- Steps:
-  1. Place skill in configured directory (default `.opencode` or `OPENCODE_CONFIG_DIR`)
-  2. Trigger skill loading via OpenCode skill tool (on-demand)
-- Expect: skill is discoverable/loadable by the skill tool
-- Source: OpenCode skills docs explain on-demand loading and skill tool behavior; config override is documented.
-
-**O2 — Commands discoverable (runtime smoke test)**
-- Evidence: FILESYSTEM + TUI
-- Steps:
-  1. Place command file in `.opencode/commands/` (project) or `~/.config/opencode/commands/` (user).
-  2. In OpenCode, type `/` and confirm the command appears; invoke it.
-- Expect: command appears and runs
-- Source: OpenCode commands docs (markdown commands + locations + invocation).
-
-**O3 — LSP server configured and starts (optional / best-effort)**
-- Evidence: FILESYSTEM + LOG/TUI
-- Steps:
-  1. Write `opencode.json` with `lsp.<server>.command` and `lsp.<server>.extensions`.
-  2. Open a file matching an extension.
-  3. Confirm LSP starts (via OpenCode logs/diagnostics if exposed) or by observing features that depend on LSP.
-- Source: OpenCode LSP docs (custom LSP config + behavior).
-- Notes: Mark best-effort if the log/diagnostic surface varies by version/build; the configuration surface itself is documented.
-
----
-
-## 10) Optional: Docker + tmux validation harness
-
-### 10.1 Rationale
-
-Some validations are inherently TUI-driven (`/` menus, slash commands). tmux can:
-- start a TUI in a session
-- send keystrokes
-- capture pane output
-- run regex assertions against captured output
-
-### 10.2 What is feasible per documented surfaces
-- Codex slash-command-based checks are explicitly documented, making tmux automation plausible.
-- Claude debug output checks are plausible via non-interactive `--debug` logs; plugin validate is CLI-based.
-- Cursor/OpenCode checks may require UI layers not intended for headless Docker; do not promise full automation without confirming headless support and stable CLIs.
-
----
-
-## 11) Deliverables
-
-### 11.1 Converter outputs
-- Emitted file tree(s) for each target
-- An install manifest (for uninstall/re-run)
-- Diagnostics describing mapping status per component
-
-### 11.2 Validator outputs
-- `ValidationReport` JSON (dumped from Pydantic)
-- Human-readable report (table + highlighted failures)
-- Evidence blobs (captured stdout/stderr/pane output)
-
----
-
-## 12) Explicit gaps / TODOs (must be resolved by additional primary research before claiming full automation)
-
-1. **Cursor skills path/version behavior is version-dependent**: Cursor indicates Agent Skills are compatible with Claude Skills format, but rollout/activation can vary (some users report it only enables when `~/.claude/skills` already exists). Do not hardcode user-global paths without primary Cursor docs confirming them; treat as conditional and include a "detection + instructions" step.
-
-2. **OpenCode CLI enumeration for skills** (not assumed; add only when documented as stable).
-
-These gaps are intentionally surfaced so the tool does not claim guarantees it cannot verify from authoritative sources.
+Changes to a real target contract also require the applicable Docker lane and
+runtime probe selected by `.agents/skills/ai-config-target-refresh/SKILL.md`.
+Contract changes must keep this specification, the relevant ADR, and the
+architecture/reference docs aligned with code and tests.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,31 @@
+# ai-config documentation
+
+MkDocs owns this directory's layout and `mkdocs.yml` navigation. Keep reference
+pages current-facing; put architectural rationale in ADRs and historical phases
+in project evolution.
+
+## Routing
+
+| Path | Purpose |
+|---|---|
+| `index.md` | Human documentation entrypoint |
+| `commands.md` | CLI command reference |
+| `config.md` | Version 1 configuration reference |
+| `conversion.md` | User-facing conversion behavior and options |
+| `explanation/architecture.md` | Current system boundaries, flows, and ownership |
+| `explanation/project-evolution.md` | Historical phases and retained tradeoffs |
+| `adr/001-use-claude-plugins-as-the-canonical-source.md` | Canonical source-format decision |
+| `adr/002-normalize-conversion-through-a-target-independent-ir.md` | IR conversion seam |
+| `adr/003-use-native-codex-plugin-packages.md` | Codex package lifecycle |
+| `adr/004-require-proven-ownership-before-generated-output-cleanup.md` | Cleanup safety boundary |
+| `adr/005-plan-sync-before-applying-it.md` | Observe-plan-apply sync boundary |
+
+## Gotchas
+
+- **DO** update `mkdocs.yml` when adding, removing, or moving a product page.
+  **NOT** rely on filesystem discovery. **BECAUSE** nav omissions are warnings
+  and strict builds treat them as release failures; this agent-only file is the
+  explicit `exclude_docs` exception and is not published.
+- **DO** keep SPEC requirements and ADR decisions linked to current code/tests.
+  **NOT** copy transient test counts or target versions into durable context.
+  **BECAUSE** runtime baselines and release facts have separate owners.

--- a/docs/adr/001-use-claude-plugins-as-the-canonical-source.md
+++ b/docs/adr/001-use-claude-plugins-as-the-canonical-source.md
@@ -1,0 +1,40 @@
+# Use Claude plugins as the canonical conversion source
+
+Status: Accepted
+Date: 2026-08-01
+Original implementation: 2026-02-12
+
+## Context
+
+ai-config began as a declarative manager for Claude Code marketplaces and
+plugins. When cross-tool conversion was added, the project needed one authoring
+format from which Codex, Cursor, and OpenCode output could be derived. The
+existing Claude bundle already carried identity, skills, commands, hooks,
+agents, MCP servers, LSP servers, and support files.
+
+[PR #3](https://github.com/safurrier/ai-config/pull/3), merged as
+`a11b2c66134b3a6304d23d4dd2daea5910244b2d`, established the implemented
+Claude-plugin-to-target pipeline while still listing bidirectional conversion
+as possible future work. The current parser in
+`src/ai_config/converters/claude_parser.py` retains the one-way source boundary;
+this ADR ratifies it as the supported contract.
+
+## Decision
+
+Treat a Claude Code plugin bundle, rooted at `.claude-plugin/plugin.json`, as
+the canonical conversion source. Parse that bundle once and emit selected
+target formats. Report Claude-only semantics that cannot be preserved rather
+than inventing an equivalent.
+
+Do not introduce a second neutral authoring format or bidirectional conversion
+contract without a new architectural decision. A target may supply native
+override files for behavior that cannot be expressed portably, but those files
+remain additions to the Claude source bundle rather than a new source authority.
+
+## Consequences
+
+Existing Claude plugin repositories can add target output without duplicating
+their core skills and configuration. The parser necessarily follows Claude's
+component vocabulary, so new Claude manifest fields require explicit parser
+support or diagnostics. Native target projects and reverse conversion remain
+outside the current contract.

--- a/docs/adr/002-normalize-conversion-through-a-target-independent-ir.md
+++ b/docs/adr/002-normalize-conversion-through-a-target-independent-ir.md
@@ -1,0 +1,36 @@
+# Normalize conversion through a target-independent IR
+
+Status: Accepted
+Date: 2026-02-12
+
+## Context
+
+Direct source-to-target transformations would repeat parsing, naming, fidelity,
+and diagnostic rules for every target. As target count grows, pairwise
+conversion paths would make it difficult to compare behavior or add a target
+without changing existing emitters.
+
+[PR #3](https://github.com/safurrier/ai-config/pull/3), merged as
+`a11b2c66134b3a6304d23d4dd2daea5910244b2d`, introduced the Parse → IR → Emit
+pipeline and independent target results. The current contracts live in
+`src/ai_config/converters/ir.py`, `claude_parser.py`, and `emitters.py`.
+
+## Decision
+
+Parse a source plugin into one typed `PluginIR` containing normalized identity,
+components, source paths, and diagnostics. Give the same immutable logical
+representation to each target emitter. Each emitter produces its own
+`EmitResult`, mappings, files, cleanup candidates, and diagnostics.
+
+Record conversion fidelity with the shared `MappingStatus` vocabulary instead
+of treating a written file as proof of semantic equivalence. Keep target
+lifecycle and installation decisions outside the IR.
+
+## Consequences
+
+Parsers and emitters have separate ownership, new targets reuse one normalized
+input, and reports can compare fidelity consistently. The IR becomes a durable
+internal compatibility seam: adding a component or changing normalization can
+affect every emitter and requires cross-target tests. Target-only concepts stay
+in emitters, lifecycle plans, or native override files rather than distorting
+the shared model.

--- a/docs/adr/003-use-native-codex-plugin-packages.md
+++ b/docs/adr/003-use-native-codex-plugin-packages.md
@@ -1,0 +1,33 @@
+# Use native Codex plugin packages
+
+Status: Accepted
+Date: 2026-07-17
+
+## Context
+
+ai-config's first Codex target wrote loose skills, prompts, hooks, and shared
+MCP configuration. Codex later added installable plugin packages and
+marketplaces, providing a native lifecycle with one package identity. The loose
+model left ai-config imitating ownership and mutating shared configuration.
+
+[PR #17](https://github.com/safurrier/ai-config/pull/17) evaluated keeping loose
+output, adding an opt-in package target, or moving to packages. After runtime
+proof, [PR #19](https://github.com/safurrier/ai-config/pull/19), merged as
+`9983cc993795fb24871e3f62f19517066356b830`, made packages the sole Codex target.
+
+## Decision
+
+Emit one deterministic Codex plugin package and local marketplace per source
+plugin. Use the Codex CLI to inspect, register, install, update, repair, and
+remove packages. ai-config owns generated package sources and its ownership
+record; Codex owns installed cache, enablement, and shared runtime configuration.
+
+Do not emit legacy loose Codex skills, prompts, hooks, or MCP tables.
+
+## Consequences
+
+Codex conversion follows the target's native lifecycle and reconciles a plugin
+as one identity. Package manifests, selectors, SemVer, marketplace state, and
+Codex CLI response schemas are compatibility boundaries. The 0.6.0 transition
+was intentionally breaking, and old loose output remains outside automatic
+deletion when ownership cannot be proved.

--- a/docs/adr/004-require-proven-ownership-before-generated-output-cleanup.md
+++ b/docs/adr/004-require-proven-ownership-before-generated-output-cleanup.md
@@ -1,0 +1,37 @@
+# Require proven ownership before generated output cleanup
+
+Status: Accepted
+Date: 2026-07-26
+
+## Context
+
+Converted files are runtime-discoverable state. Without durable ownership,
+renaming, disabling, or removing a source can leave stale output, while broad
+cleanup risks deleting files created or edited by the user or another tool.
+
+The Codex package lifecycle introduced bounded ownership in
+[PR #19](https://github.com/safurrier/ai-config/pull/19). Pi adopted per-file
+ownership in [PR #24](https://github.com/safurrier/ai-config/pull/24), merged as
+`f3543417abda9296a7ebe2080e019a4f315fc3a7`, after loose Pi output was shown to
+survive source removal.
+
+## Decision
+
+Require target-appropriate ownership evidence before cleanup. For Codex, record
+package and marketplace identities plus reserved generated roots. For Pi,
+record source identity, relative path, content digest, and executable mode.
+
+Remove or replace only matching owned state and preserve historical unowned
+output. Pi additionally preserves locally modified owned files by comparing
+content digests. Codex owns its complete generated marketplace root and may
+replace or remove that root once its recorded identity and path match. Reject
+unowned collisions, malformed records, traversal, symlinked output, and
+conflicting ownership domains. Cursor and OpenCode remain path-contained but do
+not gain an ownership ledger without a separately evidenced lifecycle design.
+
+## Consequences
+
+Codex and Pi can reconcile removals without claiming unrelated runtime state.
+Interrupted Pi work retains transaction evidence for safe retry. Ownership
+schemas and recovery behavior are compatibility contracts, and ambiguous state
+stops sync for deliberate human cleanup instead of guessing.

--- a/docs/adr/005-plan-sync-before-applying-it.md
+++ b/docs/adr/005-plan-sync-before-applying-it.md
@@ -1,0 +1,36 @@
+# Plan sync before applying it
+
+Status: Accepted
+Date: 2026-07-29
+
+## Context
+
+Sync spans external Claude state, plugin sources, generated artifacts, target
+lifecycle commands, caches, and ownership ledgers. Interleaving observation,
+decisions, and mutation made dry-run parity, stale-input detection, and
+partial-progress reporting difficult to establish.
+
+[PR #26](https://github.com/safurrier/ai-config/pull/26), merged as
+`693442307dbd54b1c8e0f9bb4a17937f98539a2f`, introduced the current phase
+boundary and characterization coverage. The data contracts live in
+`src/ai_config/sync_pipeline.py`; observation and execution are separated in
+`sync_orchestration.py` and `sync_conversion.py`.
+
+## Decision
+
+Run normal sync as explicit observation, immutable snapshot construction,
+deterministic planning, validation, apply, and reporting phases. Dry-run and
+real execution consume the same typed, ordered `SyncPlan`.
+
+Planning is mutation-free. Apply validates its preconditions and executes the
+materialized plan without rebuilding decisions. Target lifecycle code retains
+authority for target-specific checks and actions but cannot bypass the plan as
+the authorization boundary.
+
+## Consequences
+
+Dry-run describes the actions that real execution would consume, and planning
+can be tested without external mutation. Plans carry emitted data, ownership
+snapshots, and checkpoints, so they are larger than simple action lists. A real
+`--fresh` cache clear remains outside the pure transform because it must happen
+before observation; fresh dry-run remains mutation-free.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,94 @@
+# Architecture
+
+ai-config separates declarative intent, observed runtime state, conversion,
+target lifecycle, and mutation. This keeps a preview useful without letting a
+generated file or a target CLI response silently become configuration.
+
+## System boundaries
+
+```text
+versioned YAML configuration
+          |
+          v
+configuration + source discovery -----> Claude runtime observation
+          |                                      |
+          +--------------+-----------------------+
+                         v
+               immutable sync planning
+                         |
+              +----------+-----------+
+              |                      |
+              v                      v
+       Claude reconciliation   conversion planning
+                                      |
+                           Claude bundle -> PluginIR
+                                      |
+                       +--------------+-------------+
+                       v              v             v
+                    Codex       Cursor/OpenCode     Pi
+                   package          files          files
+                       |                             |
+                 Codex CLI                    Pi ownership
+```
+
+The Click CLI in `src/ai_config/cli.py` is a thin entrypoint. Configuration
+parsing lives in `config.py` and frozen schema types in `types.py`. Stable
+operations delegate sync work to `sync_orchestration.py`, while
+`sync_pipeline.py` owns immutable desired, observed, plan, action, diagnostic,
+and report records.
+
+## Sync flow
+
+Normal sync has five boundaries:
+
+1. Observe configured sources, Claude state, caches, target output, and
+   ownership records.
+2. Build immutable `DesiredState`, `RuntimeSnapshot`, and `SourceBatch` values.
+3. Produce and structurally validate one ordered `SyncPlan`.
+4. Recheck preconditions and apply only the materialized actions.
+5. Report completed, failed, skipped, and checkpoint outcomes.
+
+Planning performs no state-changing calls. A real `--fresh` clears Claude cache
+before observation because that changes the observable input; fresh dry-run
+does not clear it. The detailed data flow is documented in the repository's
+[`ai_agent_docs/conversion-pipeline.md`](https://github.com/safurrier/ai-config/blob/main/ai_agent_docs/conversion-pipeline.md).
+
+## Conversion flow
+
+`ClaudePluginParser` reads `.claude-plugin/plugin.json` and supported component
+directories into a `PluginIR`. The IR normalizes identity and component shapes
+but retains source paths and diagnostics. Independent emitters then return
+target-specific `EmitResult` objects; they never mutate the shared IR.
+
+Mapping status is part of the result: `native`, `transform`, `emulate`,
+`fallback`, or `unsupported`. Target-native files under `targets/<target>/`
+overlay generated output at the target's natural root and are still subject to
+path and ownership safety.
+
+## Target ownership
+
+| Target | Output and lifecycle authority | Cleanup boundary |
+|---|---|---|
+| Claude | Claude marketplaces and plugin CLI | Desired-vs-observed reconciliation |
+| Codex | Generated package/marketplace sources plus Codex plugin CLI | Recorded package identity and reserved generated root |
+| Cursor | `.cursor/` files and JSON configuration | Validated output-root containment |
+| OpenCode | `.opencode/` plus JSON configuration | Validated output-root containment |
+| Pi | Project `.pi/` or user `~/.pi/agent/` files | Recorded source, path, digest, and mode |
+
+Codex and Pi can remove only state proven to belong to ai-config. Cursor and
+OpenCode writes are contained but do not currently have equivalent durable
+ownership ledgers. An unavailable source retains prior ownership and cannot
+authorize cleanup merely by disappearing from observation.
+
+## Extension and proof seams
+
+New source components extend `PluginIR` and every affected emitter. New targets
+add an emitter, output validator, configuration/CLI choice, tests, docs, and a
+runtime probe when the target exposes one. The repo-local
+`ai-config-target-refresh` skill owns compatibility audits for external tool
+changes.
+
+Unit tests cover pure planning, parsing, emission, validation, and safety
+boundaries. Integration tests exercise local workflows. Docker E2E and isolated
+target probes supply real-tool evidence for contracts that file inspection
+cannot prove.

--- a/docs/explanation/project-evolution.md
+++ b/docs/explanation/project-evolution.md
@@ -1,0 +1,77 @@
+# Project evolution
+
+ai-config evolved from a Claude-only declarative installer into a cross-tool
+conversion and reconciliation system. The phases below record why the current
+boundaries exist; individual feature changes remain in the changelog.
+
+## Declarative Claude management
+
+The initial release made a YAML file authoritative for Claude marketplaces and
+plugins. `init`, `sync`, `status`, `update`, `watch`, `doctor`, and plugin
+scaffolding established the desired-vs-installed model that still anchors the
+CLI. PyPI publishing and Docker E2E followed so the tool could be installed and
+tested outside one workstation.
+
+Evidence: initial commit `499cb2b612d26909c6787775401b76e806384310`,
+[PR #1](https://github.com/safurrier/ai-config/pull/1), and
+[PR #2](https://github.com/safurrier/ai-config/pull/2).
+
+## One source, multiple targets
+
+[PR #3](https://github.com/safurrier/ai-config/pull/3) added the cross-tool
+pipeline. Claude plugin bundles remained the authoring source, while a typed IR
+separated parsing from Codex, Cursor, and OpenCode emitters. Fidelity statuses
+made unsupported and degraded mappings visible. Pi joined through the same seam
+in [PR #8](https://github.com/safurrier/ai-config/pull/8).
+
+The init rewrite and environment-variable path support in
+[PR #7](https://github.com/safurrier/ai-config/pull/7) made the declarative
+configuration portable across machines. Target-native overrides in
+[PR #16](https://github.com/safurrier/ai-config/pull/16) added an escape hatch
+for target-specific behavior without replacing the canonical source or IR.
+
+## From emitted files to target lifecycles
+
+Early targets mostly wrote loose files. Runtime audits then showed that target
+discovery paths and capabilities change independently: Pi user files moved
+under `~/.pi/agent/`, Codex discovery and hook/MCP paths changed, and shared
+configuration needed merge behavior.
+
+[PR #17](https://github.com/safurrier/ai-config/pull/17) evaluated Codex's new
+package surface. [PR #19](https://github.com/safurrier/ai-config/pull/19) then
+replaced loose Codex output with native packages and an ownership-aware CLI
+lifecycle. This was a deliberate breaking change, not a new parallel target.
+
+## Proven ownership before cleanup
+
+Native lifecycle introduced a sharper safety question: absence from desired
+state is not proof that a runtime path belongs to ai-config. Codex therefore
+records package and marketplace identity. After stale loose Pi files were
+observed, [PR #24](https://github.com/safurrier/ai-config/pull/24) added
+per-file source, path, digest, mode, and pending-transaction evidence.
+
+Historical unowned output remains a human cleanup decision. Cursor and OpenCode
+remain path-contained but do not claim the stronger ledger contract.
+
+## Plan before mutation
+
+As sync accumulated Claude state, conversion, target CLI actions, caches, and
+ownership checkpoints, interleaved decision-making made dry-run parity and
+partial failure hard to reason about. [PR #26](https://github.com/safurrier/ai-config/pull/26)
+reframed sync as observation, immutable snapshot, deterministic plan,
+validation, apply, and reporting.
+
+The current system therefore has two durable internal seams: Parse → IR → Emit
+for conversion, and Observe → Plan → Apply for reconciliation. The former
+separates source semantics from target representation; the latter separates
+evidence and authorization from mutation.
+
+## Decision timeline
+
+| Effective date | Lasting decision | Current record |
+|---|---|---|
+| 2026-02-12 | All targets receive one normalized IR | [ADR 002](../adr/002-normalize-conversion-through-a-target-independent-ir.md) |
+| 2026-07-17 | Codex uses native plugin packages rather than loose output | [ADR 003](../adr/003-use-native-codex-plugin-packages.md) |
+| 2026-07-26 | Cleanup requires durable ownership proof | [ADR 004](../adr/004-require-proven-ownership-before-generated-output-cleanup.md) |
+| 2026-07-29 | Sync materializes a plan before normal mutation | [ADR 005](../adr/005-plan-sync-before-applying-it.md) |
+| 2026-08-01 | Ratify Claude plugins as the canonical conversion source; implementation began 2026-02-12 | [ADR 001](../adr/001-use-claude-plugins-as-the-canonical-source.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,10 @@ Check your `.ai-config/config.yaml` into your dotfiles. Run `ai-config sync` on 
 
 ## What's Next
 
+- [Specification](https://github.com/safurrier/ai-config/blob/main/SPEC.md) — Normative current-truth correctness envelope
 - [Commands](commands.md) — Full command reference
 - [Configuration](config.md) — Config file format and examples
 - [Conversion](conversion.md) — Converting plugins to other AI tools
+- [Architecture](explanation/architecture.md) — System boundaries, flows, and ownership
+- [Project evolution](explanation/project-evolution.md) — How the current design emerged
+- [Architecture decisions](adr/001-use-claude-plugins-as-the-canonical-source.md) — Lasting choices and rationale

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,13 @@ plugins:
             show_signature_annotations: true
             separate_signature: true
 
+exclude_docs: |
+  AGENTS.md
+
+validation:
+  nav:
+    omitted_files: warn
+
 markdown_extensions:
   - admonition
   - attr_list
@@ -68,6 +75,15 @@ nav:
   - Commands: commands.md
   - Configuration: config.md
   - Conversion: conversion.md
+  - Explanation:
+      - Architecture: explanation/architecture.md
+      - Project evolution: explanation/project-evolution.md
+  - Decisions:
+      - Canonical Claude source: adr/001-use-claude-plugins-as-the-canonical-source.md
+      - Target-independent IR: adr/002-normalize-conversion-through-a-target-independent-ir.md
+      - Native Codex packages: adr/003-use-native-codex-plugin-packages.md
+      - Proven ownership: adr/004-require-proven-ownership-before-generated-output-cleanup.md
+      - Plan before apply: adr/005-plan-sync-before-applying-it.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary

- bootstrap the canonical six-section `SPEC.md` from current repository truth
- record five evidence-backed architectural decisions, including the Claude-plugin source model and target-independent IR
- add current-system architecture and project-evolution explanations
- route contributors and readers through the new context from `AGENTS.md`, the README, and the docs site

## Why

This is the clean-room dogfood run for context-engineering's complete-picture bootstrap. It starts from `origin/main` with the existing context documentation removed except `AGENTS.md`, then reconstructs the specification, decisions, architecture, and historical evolution from code, Git history, and merged PRs.

It intentionally replaces the former lean SPEC shape with the canonical contract; no legacy SPEC profile is preserved.

For comparison, PR #28 remains unchanged. Relative to that run, this PR adds the missing source-format and IR decisions, a system architecture explanation, a historical evolution narrative, strict canonical SPEC validation, and clearer context routing.

Plugin implementation and eval coverage: safurrier/dots#506.

## Validation

- `git diff --check`
- Ruff check and format check
- ty type check
- strict MkDocs build
- context-engineering SPEC/ADR contract validation
- context-engineering docs structure verification
- integration tests: 8 passed
- fresh-context Sol/xhigh review, followed by a clean P0-P3 re-review

The broader local unit run passed 790 of 792 tests. The two remaining failures reproduce on untouched `origin/main` and are host/timing-sensitive: descendant-process timeout cleanup and live Pi ownership state leaking into sync verification.
