### PR TITLE
Expand Ruff coverage to tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run Linter
-        run: uv run ruff check src/
+        run: uv run ruff check src/ tests/
 
       - name: Run Formatter Check
-        run: uv run ruff format --check src/
+        run: uv run ruff format --check src/ tests/
 
       - name: Run Type Checker
         run: uv run ty check src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     hooks:
     -   id: lint
         name: Run Linter
-        entry: env -u VIRTUAL_ENV uv run --python .venv/bin/python ruff check src/
+        entry: env -u VIRTUAL_ENV uv run --python .venv/bin/python ruff check src/ tests/
         language: system
         always_run: true
         pass_filenames: false
     -   id: format
         name: Run Formatter
-        entry: env -u VIRTUAL_ENV uv run --python .venv/bin/python ruff format --check src/
+        entry: env -u VIRTUAL_ENV uv run --python .venv/bin/python ruff format --check src/ tests/
         language: system
         always_run: true
         pass_filenames: false

--- a/justfile
+++ b/justfile
@@ -10,17 +10,17 @@ setup:
 # Run all code quality checks
 check: lint ty test
 
-# Lint source code
+# Lint source and test code
 lint:
-    uv run ruff check src/
+    uv run ruff check src/ tests/
 
-# Format source code
+# Format source and test code
 format:
-    uv run ruff format src/
+    uv run ruff format src/ tests/
 
 # Fix linting issues
 fix:
-    uv run ruff check src/ --fix
+    uv run ruff check src/ tests/ --fix
 
 # Type check with ty
 ty:


### PR DESCRIPTION
AI-authored PR from the Nightshift Codex trial.

## Summary

- Run Ruff lint and formatting checks across both `src/` and `tests/`.
- Keep the Just recipes and pre-commit hooks aligned.
- No Python source files required mechanical changes.

## Validation

- Ruff check: passed
- Ruff format check: passed
- ty: passed
- Unit tests: 792 passed in Nightshift isolated validation
- Pre-commit hooks: passed

Nightshift task: `lint-fix`