### PR TITLE
Add repository ownership boundaries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,46 @@
+# Default owner for repository-wide changes.
+* @safurrier
+
+# Command-line interface, configuration schema, and source-of-truth types.
+/src/ai_config/cli.py @safurrier
+/src/ai_config/__main__.py @safurrier
+/src/ai_config/cli_render.py @safurrier
+/src/ai_config/cli_theme.py @safurrier
+/src/ai_config/config.py @safurrier
+/src/ai_config/settings.py @safurrier
+/src/ai_config/types.py @safurrier
+/src/ai_config/init.py @safurrier
+/src/ai_config/scaffold.py @safurrier
+
+# Claude runtime adapter and sync planning/execution lifecycle.
+/src/ai_config/adapters/ @safurrier
+/src/ai_config/operations.py @safurrier
+/src/ai_config/sync_pipeline.py @safurrier
+/src/ai_config/sync_orchestration.py @safurrier
+/src/ai_config/sync_conversion.py @safurrier
+/src/ai_config/sync_state.py @safurrier
+/src/ai_config/watch.py @safurrier
+
+# Target-neutral conversion and destructive target-output ownership semantics.
+/src/ai_config/converters/ @safurrier
+/src/ai_config/codex_lifecycle.py @safurrier
+/src/ai_config/pi_ownership.py @safurrier
+/src/ai_config/output_safety.py @safurrier
+
+# Validation framework and target compatibility checks.
+/src/ai_config/validators/ @safurrier
+
+# Test suites, fixtures, and Docker-backed end-to-end infrastructure.
+/tests/unit/ @safurrier
+/tests/integration/ @safurrier
+/tests/e2e/ @safurrier
+/tests/fixtures/ @safurrier
+/tests/docker/ @safurrier
+
+# User-facing architecture, operational documentation, and agent guidance.
+/docs/ @safurrier
+/ai_agent_docs/ @safurrier
+/AGENTS.md @safurrier
+/src/AGENTS.md @safurrier
+/README.md @safurrier
+/SPEC.md @safurrier


### PR DESCRIPTION
## Ownership boundaries

Adds GitHub review ownership metadata with `@safurrier` as the repository-wide fallback owner. Path rules document the existing responsibility seams for CLI/configuration, sync execution, conversion targets, validation, tests, and documentation.

The fallback keeps every tracked path owned; later path-specific rules make the intended review boundaries explicit without splitting coupled contracts or assigning unverified teams.

## Validation

Confirmed GitHub-compatible rule shape and generated conversion-output exclusions. The full unit suite passes (793 tests).


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: ownership-boundary:/Users/alexfurrier/.local/state/nightshift-trial-20260808/home/git_repositories/ai-config
task-type: ownership-boundary
task-title: Ownership Boundary Suggester
provider: codex
score: 3.0
cost-tier: Medium (50-150k)
branch: main
iterations: 1
duration: 7m34s
run-started: 2026-08-09T12:12:31-07:00
nightshift:metadata -->
