### PR TITLE
Add bus-factor history analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ai-config bus-factor`, a read-only Git-history analyzer for repository and file-level change concentration, with configurable windows, thresholds, limits, and JSON output.
 - Current system specification, architecture overview, project-evolution timeline,
   and six evidence-backed architecture decisions for plugin source, target-neutral
   IR, target-native overrides, Codex packages, ownership, and observe-plan-apply sync.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Relative local marketplace paths and conversion output paths are resolved from t
 | Rebuild stale output | `ai-config sync --fresh` | Clears cache and re-converts everything. |
 | Re-run conversion only | `ai-config sync --force-convert` | Useful after changing conversion targets. |
 | Develop local plugins | `ai-config watch` | Add `--dry-run` if you only want file-change reports. |
+| Check historical change concentration | `ai-config bus-factor --since "1 year ago"` | Read-only Git-history risk signal; it is not formal ownership. |
 
 For options and examples, use [Commands](docs/commands.md). For target behavior and fidelity notes, use [Conversion](docs/conversion.md).
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,7 @@ Complete reference for all ai-config commands.
 | `watch` | Auto-sync on file changes |
 | `update` | Update plugins to latest versions |
 | `doctor` | Validate setup and show fix hints |
+| `bus-factor` | Analyze historical change concentration |
 | `convert` | Convert plugins to other AI tools |
 | `plugin create` | Scaffold a new plugin |
 | `cache clear` | Clear the plugin cache |
@@ -165,6 +166,29 @@ ai-config update PLUGIN1 PLUGIN2
 | `PLUGINS` | Specific plugin IDs to update (positional, space-separated) |
 
 You must specify either `--all` or one or more plugin names.
+
+## bus-factor
+
+Analyze historical change concentration in the current Git repository, or an explicit path.
+
+```bash
+ai-config bus-factor
+ai-config bus-factor ../another-repository --since "1 year ago" --threshold 0.7
+ai-config bus-factor --json
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--since DATE` | Only include commits newer than a Git date expression |
+| `--threshold NUMBER` | Coverage and dominant-file threshold from greater than 0 through 1 (default: `0.5`) |
+| `--limit NUMBER` | Maximum files in the result, from 1 through 1000 (default: `20`) |
+| `--json` | Output stable machine-readable JSON |
+
+The report uses non-merge commits and changed-file touch counts. It includes total contributors, the top contributor's share of commits, the minimum number of contributors required to reach the threshold, and files whose dominant contributor exceeds that threshold. Contributor identities are not printed.
+
+Commit history measures historical change concentration; it is a useful risk signal, not formal organizational ownership. Renamed files, pair work, reviews, and work done outside Git are not represented.
 
 ## doctor
 

--- a/src/ai_config/bus_factor.py
+++ b/src/ai_config/bus_factor.py
@@ -1,0 +1,216 @@
+"""Read-only Git history analysis for change-concentration risk."""
+
+from __future__ import annotations
+
+import subprocess
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_THRESHOLD = 0.5
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 1_000
+_RECORD_SEPARATOR = "\x1e"
+_FIELD_SEPARATOR = "\x1f"
+
+
+class GitHistoryError(RuntimeError):
+    """Raised when Git history cannot be inspected."""
+
+
+@dataclass(frozen=True)
+class CommitTouch:
+    """A contributor and the files touched by one non-merge commit."""
+
+    contributor: str
+    files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FileConcentration:
+    """Change concentration for one file, without exposing contributor identity."""
+
+    path: str
+    total_touches: int
+    dominant_share: float
+
+    def to_dict(self) -> dict[str, str | int | float]:
+        """Return stable machine-readable output."""
+        return {
+            "path": self.path,
+            "total_touches": self.total_touches,
+            "dominant_share": self.dominant_share,
+        }
+
+
+@dataclass(frozen=True)
+class BusFactorReport:
+    """Aggregated historical change concentration for one repository."""
+
+    repository: Path
+    since: str | None
+    threshold: float
+    commits_analyzed: int
+    total_contributors: int
+    top_contributor_share: float
+    contributors_for_threshold: int
+    files: tuple[FileConcentration, ...]
+    high_risk_files: tuple[FileConcentration, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a privacy-preserving, stable machine-readable report."""
+        return {
+            "repository": str(self.repository),
+            "since": self.since,
+            "threshold": self.threshold,
+            "commits_analyzed": self.commits_analyzed,
+            "total_contributors": self.total_contributors,
+            "top_contributor_share": self.top_contributor_share,
+            "contributors_for_threshold": self.contributors_for_threshold,
+            "files": [file.to_dict() for file in self.files],
+            "high_risk_files": [file.to_dict() for file in self.high_risk_files],
+        }
+
+
+def normalize_contributor(email: str) -> str:
+    """Normalize a Git email address into a stable contributor key."""
+    return email.strip().lower()
+
+
+def parse_git_log(output: str) -> tuple[CommitTouch, ...]:
+    """Parse output from :func:`read_commit_touches`'s Git command."""
+    commits: list[CommitTouch] = []
+    for record in output.split(_RECORD_SEPARATOR):
+        if not record:
+            continue
+        header, separator, file_text = record.partition("\n")
+        fields = header.split(_FIELD_SEPARATOR)
+        if not separator or len(fields) != 2:
+            continue
+        contributor = normalize_contributor(fields[1])
+        if not contributor:
+            continue
+        files = tuple(path for path in file_text.splitlines() if path)
+        commits.append(CommitTouch(contributor=contributor, files=files))
+    return tuple(commits)
+
+
+def _run_git(repository: Path, arguments: list[str]) -> str:
+    """Run Git without a shell and translate failures into actionable errors."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repository), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            shell=False,
+        )
+    except FileNotFoundError as error:
+        raise GitHistoryError("Git is required to analyze history but was not found.") from error
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "Git returned no details."
+        raise GitHistoryError(f"Unable to read Git history: {detail}")
+    return result.stdout
+
+
+def read_commit_touches(repository: Path, since: str | None = None) -> tuple[CommitTouch, ...]:
+    """Read non-merge commits and changed file names from a Git worktree."""
+    if not repository.exists() or not repository.is_dir():
+        raise GitHistoryError(f"Repository path does not exist or is not a directory: {repository}")
+    is_worktree = _run_git(repository, ["rev-parse", "--is-inside-work-tree"]).strip()
+    if is_worktree != "true":
+        raise GitHistoryError(f"Not a Git worktree: {repository}")
+
+    arguments = ["log", "--no-merges", f"--format={_RECORD_SEPARATOR}%an{_FIELD_SEPARATOR}%ae"]
+    if since:
+        arguments.append(f"--since={since}")
+    arguments.append("--name-only")
+    return parse_git_log(_run_git(repository, arguments))
+
+
+def _share(count: int, total: int) -> float:
+    return round(count / total, 4) if total else 0.0
+
+
+def _contributors_for_threshold(counts: Counter[str], total: int, threshold: float) -> int:
+    covered = 0
+    for index, count in enumerate(sorted(counts.values(), reverse=True), start=1):
+        covered += count
+        if covered / total >= threshold:
+            return index
+    return 0
+
+
+def analyze_commit_touches(
+    commits: tuple[CommitTouch, ...],
+    threshold: float = DEFAULT_THRESHOLD,
+    limit: int = DEFAULT_LIMIT,
+) -> BusFactorReport:
+    """Calculate repository and file concentration metrics from commit touches."""
+    contributor_touches: Counter[str] = Counter()
+    file_touches: dict[str, Counter[str]] = defaultdict(Counter)
+    for commit in commits:
+        contributor_touches[commit.contributor] += 1
+        for path in set(commit.files):
+            file_touches[path][commit.contributor] += 1
+
+    total_commits = len(commits)
+    top_count = max(contributor_touches.values(), default=0)
+    files = tuple(
+        sorted(
+            (
+                FileConcentration(
+                    path=path,
+                    total_touches=sum(contributors.values()),
+                    dominant_share=_share(max(contributors.values()), sum(contributors.values())),
+                )
+                for path, contributors in file_touches.items()
+            ),
+            key=lambda file: (-file.dominant_share, -file.total_touches, file.path),
+        )[:limit]
+    )
+    high_risk_files = tuple(file for file in files if file.dominant_share > threshold)
+    return BusFactorReport(
+        repository=Path(),
+        since=None,
+        threshold=threshold,
+        commits_analyzed=total_commits,
+        total_contributors=len(contributor_touches),
+        top_contributor_share=_share(top_count, total_commits),
+        contributors_for_threshold=_contributors_for_threshold(
+            contributor_touches, total_commits, threshold
+        )
+        if total_commits
+        else 0,
+        files=files,
+        high_risk_files=high_risk_files,
+    )
+
+
+def analyze_repository(
+    repository: Path,
+    since: str | None = None,
+    threshold: float = DEFAULT_THRESHOLD,
+    limit: int = DEFAULT_LIMIT,
+) -> BusFactorReport:
+    """Analyze historical change concentration for a Git worktree."""
+    if not 0 < threshold <= 1:
+        raise ValueError("Threshold must be greater than 0 and no greater than 1.")
+    if not 1 <= limit <= MAX_LIMIT:
+        raise ValueError(f"Limit must be between 1 and {MAX_LIMIT}.")
+    resolved_repository = repository.resolve()
+    analysis = analyze_commit_touches(
+        read_commit_touches(resolved_repository, since), threshold, limit
+    )
+    return BusFactorReport(
+        repository=resolved_repository,
+        since=since,
+        threshold=analysis.threshold,
+        commits_analyzed=analysis.commits_analyzed,
+        total_contributors=analysis.total_contributors,
+        top_contributor_share=analysis.top_contributor_share,
+        contributors_for_threshold=analysis.contributors_for_threshold,
+        files=analysis.files,
+        high_risk_files=analysis.high_risk_files,
+    )

--- a/src/ai_config/cli.py
+++ b/src/ai_config/cli.py
@@ -13,6 +13,7 @@ from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
+from ai_config.bus_factor import GitHistoryError, analyze_repository
 from ai_config.cli_theme import SYMBOLS, create_console
 from ai_config.config import (
     ConfigError,
@@ -41,6 +42,7 @@ COMMAND_ORDER = [
     "watch",
     "update",
     "doctor",
+    "bus-factor",
     "plugin",
     "convert",
     "cache",
@@ -79,6 +81,73 @@ def main() -> None:
     other AI tools (Codex, Cursor, OpenCode, Pi) via convert.
     """
     pass
+
+
+@main.command(
+    name="bus-factor",
+    epilog="\b\nExamples:\n"
+    "  ai-config bus-factor                 Analyze the current repository\n"
+    "  ai-config bus-factor ../project --since '1 year ago'\n"
+    "  ai-config bus-factor --threshold 0.7 --json\n",
+)
+@click.argument("repository", type=click.Path(exists=True, file_okay=False, path_type=Path), required=False)
+@click.option("--since", help="Only analyze commits newer than this Git date expression.")
+@click.option(
+    "--threshold",
+    type=click.FloatRange(min=0.0001, max=1.0),
+    default=0.5,
+    show_default=True,
+    help="Coverage and dominant-file concentration threshold (0-1).",
+)
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1, max=1000),
+    default=20,
+    show_default=True,
+    help="Maximum number of files to include.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output stable machine-readable JSON.")
+def bus_factor(
+    repository: Path | None, since: str | None, threshold: float, limit: int, as_json: bool
+) -> None:
+    """Measure historical change concentration; commit history is not ownership."""
+    try:
+        report = analyze_repository(repository or Path.cwd(), since, threshold, limit)
+    except (GitHistoryError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+
+    if as_json:
+        console.print_json(json.dumps(report.to_dict()))
+        return
+
+    console.print()
+    console.print(Panel.fit("[header]ai-config bus-factor[/header]", border_style="cyan"))
+    console.print(f"[subheader]Repository:[/subheader] {report.repository}")
+    if report.since:
+        console.print(f"[subheader]Since:[/subheader] {report.since}")
+    console.print("[dim]Commit history is a proxy for change concentration, not formal ownership.[/dim]")
+    console.print()
+    console.print(f"[subheader]Commits analyzed:[/subheader] {report.commits_analyzed}")
+    console.print(f"[subheader]Contributors:[/subheader] {report.total_contributors}")
+    console.print(f"[subheader]Top contributor share:[/subheader] {report.top_contributor_share:.1%}")
+    console.print(
+        f"[subheader]Contributors for {report.threshold:.0%} coverage:[/subheader] "
+        f"{report.contributors_for_threshold}"
+    )
+    console.print()
+    if not report.files:
+        console.print("[info]No non-merge commits found in this history window.[/info]")
+        return
+    table = Table(title="Files by dominant contributor concentration", box=None)
+    table.add_column("File", style="key")
+    table.add_column("Touches", justify="right")
+    table.add_column("Dominant share", justify="right")
+    table.add_column("Risk")
+    high_risk_paths = {file.path for file in report.high_risk_files}
+    for file in report.files:
+        risk = "high" if file.path in high_risk_paths else "-"
+        table.add_row(file.path, str(file.total_touches), f"{file.dominant_share:.1%}", risk)
+    console.print(table)
 
 
 @main.command(

--- a/src/ai_config/cli.py
+++ b/src/ai_config/cli.py
@@ -90,7 +90,9 @@ def main() -> None:
     "  ai-config bus-factor ../project --since '1 year ago'\n"
     "  ai-config bus-factor --threshold 0.7 --json\n",
 )
-@click.argument("repository", type=click.Path(exists=True, file_okay=False, path_type=Path), required=False)
+@click.argument(
+    "repository", type=click.Path(exists=True, file_okay=False, path_type=Path), required=False
+)
 @click.option("--since", help="Only analyze commits newer than this Git date expression.")
 @click.option(
     "--threshold",
@@ -125,11 +127,15 @@ def bus_factor(
     console.print(f"[subheader]Repository:[/subheader] {report.repository}")
     if report.since:
         console.print(f"[subheader]Since:[/subheader] {report.since}")
-    console.print("[dim]Commit history is a proxy for change concentration, not formal ownership.[/dim]")
+    console.print(
+        "[dim]Commit history is a proxy for change concentration, not formal ownership.[/dim]"
+    )
     console.print()
     console.print(f"[subheader]Commits analyzed:[/subheader] {report.commits_analyzed}")
     console.print(f"[subheader]Contributors:[/subheader] {report.total_contributors}")
-    console.print(f"[subheader]Top contributor share:[/subheader] {report.top_contributor_share:.1%}")
+    console.print(
+        f"[subheader]Top contributor share:[/subheader] {report.top_contributor_share:.1%}"
+    )
     console.print(
         f"[subheader]Contributors for {report.threshold:.0%} coverage:[/subheader] "
         f"{report.contributors_for_threshold}"

--- a/tests/unit/test_bus_factor.py
+++ b/tests/unit/test_bus_factor.py
@@ -1,0 +1,99 @@
+"""Tests for read-only Git-history concentration analysis."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ai_config.bus_factor import (
+    CommitTouch,
+    GitHistoryError,
+    analyze_commit_touches,
+    analyze_repository,
+    normalize_contributor,
+    parse_git_log,
+    read_commit_touches,
+)
+
+
+def test_normalize_contributor_uses_lowercase_trimmed_email() -> None:
+    assert normalize_contributor("  Ada@Example.COM ") == "ada@example.com"
+
+
+def test_parse_git_log_reads_non_merge_commit_files() -> None:
+    output = "\x1eAda\x1fADA@example.com\nsrc/app.py\nREADME.md\n\x1eBob\x1fbob@example.com\nsrc/app.py\n"
+
+    assert parse_git_log(output) == (
+        CommitTouch("ada@example.com", ("src/app.py", "README.md")),
+        CommitTouch("bob@example.com", ("src/app.py",)),
+    )
+
+
+def test_parse_git_log_ignores_malformed_or_identityless_records() -> None:
+    assert parse_git_log("\x1ebad\nfile.py\n\x1eName\x1f\nfile.py\n") == ()
+
+
+def test_analysis_calculates_concentration_and_deterministic_file_order() -> None:
+    report = analyze_commit_touches(
+        (
+            CommitTouch("ada@example.com", ("b.py", "a.py", "a.py")),
+            CommitTouch("ada@example.com", ("b.py",)),
+            CommitTouch("bob@example.com", ("a.py",)),
+        ),
+        threshold=0.5,
+        limit=10,
+    )
+
+    assert report.commits_analyzed == 3
+    assert report.total_contributors == 2
+    assert report.top_contributor_share == 0.6667
+    assert report.contributors_for_threshold == 1
+    assert [(file.path, file.total_touches, file.dominant_share) for file in report.files] == [
+        ("b.py", 2, 1.0),
+        ("a.py", 2, 0.5),
+    ]
+    assert [file.path for file in report.high_risk_files] == ["b.py"]
+
+
+def test_analysis_handles_empty_and_binary_file_histories() -> None:
+    empty = analyze_commit_touches((), threshold=0.5, limit=10)
+    binary = analyze_commit_touches(
+        (CommitTouch("ada@example.com", ("assets/logo.png",)),), threshold=0.5, limit=10
+    )
+
+    assert empty.total_contributors == empty.contributors_for_threshold == 0
+    assert empty.files == ()
+    assert binary.files[0].path == "assets/logo.png"
+    assert binary.files[0].dominant_share == 1.0
+
+
+def test_read_commit_touches_uses_git_without_shell_and_since(tmp_path: Path) -> None:
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="true\n", stderr="")
+    log = subprocess.CompletedProcess(
+        ["git"], 0, stdout="\x1eAda\x1fada@example.com\na.py\n", stderr=""
+    )
+    with patch("ai_config.bus_factor.subprocess.run", side_effect=[completed, log]) as run:
+        commits = read_commit_touches(tmp_path, "2026-01-01")
+
+    assert commits == (CommitTouch("ada@example.com", ("a.py",)),)
+    command = run.call_args_list[1].args[0]
+    assert command[:3] == ["git", "-C", str(tmp_path)]
+    assert "--since=2026-01-01" in command
+    assert run.call_args_list[1].kwargs["shell"] is False
+
+
+def test_subprocess_failure_has_actionable_error(tmp_path: Path) -> None:
+    failed = subprocess.CompletedProcess(["git"], 128, stdout="", stderr="not a repository")
+    with patch("ai_config.bus_factor.subprocess.run", return_value=failed):
+        with pytest.raises(GitHistoryError, match="Unable to read Git history: not a repository"):
+            read_commit_touches(tmp_path)
+
+
+def test_analyze_repository_rejects_invalid_bounds(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Threshold"):
+        analyze_repository(tmp_path, threshold=0)
+    with pytest.raises(ValueError, match="Limit"):
+        analyze_repository(tmp_path, limit=0)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 from click.testing import CliRunner
 
 from ai_config.adapters.claude import CommandResult, InstalledMarketplace, InstalledPlugin
+from ai_config.bus_factor import BusFactorReport, FileConcentration, GitHistoryError
 from ai_config.cli import main
 from ai_config.converters.ir import PluginIdentity, TargetTool
 from ai_config.converters.report import ConversionReport
@@ -139,6 +140,67 @@ class TestMainGroup:
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == 0
         assert "ai-config" in result.output
+
+
+class TestBusFactorCommand:
+    """Tests for historical change-concentration CLI output."""
+
+    def test_default_output(self, runner: CliRunner, tmp_path: Path) -> None:
+        report = BusFactorReport(
+            repository=tmp_path,
+            since=None,
+            threshold=0.5,
+            commits_analyzed=2,
+            total_contributors=1,
+            top_contributor_share=1.0,
+            contributors_for_threshold=1,
+            files=(FileConcentration("src/app.py", 2, 1.0),),
+            high_risk_files=(FileConcentration("src/app.py", 2, 1.0),),
+        )
+        with patch("ai_config.cli.analyze_repository", return_value=report):
+            result = runner.invoke(main, ["bus-factor", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "Top contributor share" in result.output
+        assert "src/app.py" in result.output
+        assert "formal ownership" in result.output
+
+    def test_json_output_and_options(self, runner: CliRunner, tmp_path: Path) -> None:
+        report = BusFactorReport(tmp_path, "1 year ago", 0.7, 0, 0, 0.0, 0, (), ())
+        with patch("ai_config.cli.analyze_repository", return_value=report) as analyze:
+            result = runner.invoke(
+                main,
+                [
+                    "bus-factor",
+                    str(tmp_path),
+                    "--since",
+                    "1 year ago",
+                    "--threshold",
+                    "0.7",
+                    "--limit",
+                    "4",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output)["contributors_for_threshold"] == 0
+        assert analyze.call_args.args[1:] == ("1 year ago", 0.7, 4)
+
+    def test_invalid_bounds_and_non_git_path_fail_actionably(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        invalid = runner.invoke(main, ["bus-factor", "--threshold", "2"])
+        with patch(
+            "ai_config.cli.analyze_repository",
+            side_effect=GitHistoryError("Not a Git worktree"),
+        ):
+            non_git = runner.invoke(main, ["bus-factor", str(tmp_path)])
+
+        assert invalid.exit_code == 2
+        assert "Invalid value" in invalid.output
+        assert non_git.exit_code == 1
+        assert "Not a Git worktree" in non_git.output
 
 
 class TestSyncCommand:


### PR DESCRIPTION
## Historical concentration analysis

Adds `ai-config bus-factor`, a read-only Git-history report for contributor and file change concentration. It supports a history window, configurable coverage threshold, result limit, and stable JSON output.

The command deliberately treats commit history as a risk signal rather than organizational ownership, excludes merge commits, and omits contributor identities from output. Coverage includes parsing, aggregation, bounds, subprocess failures, CLI rendering, and JSON behavior.

Validated with Ruff, ty, and the full 804-test unit suite.


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: bus-factor:/Users/alexfurrier/.local/state/nightshift-trial-20260808/home/git_repositories/ai-config
task-type: bus-factor
task-title: Bus-Factor Analyzer
provider: codex
score: 3.0
cost-tier: Medium (50-150k)
branch: main
iterations: 1
duration: 11m10s
run-started: 2026-08-10T02:35:47-07:00
nightshift:metadata -->
