### PR TITLE
Respect Claude profile directory when clearing cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validate the observed Codex plugin lifecycle contract through Codex CLI 0.147.x.
 
+### Fixed
+
+- Claude cache clearing now respects `CLAUDE_CONFIG_DIR`, so fresh syncs for
+  alternate profiles remove the intended profile cache without affecting the
+  default profile.
+
 ## [0.6.2] - 2026-07-29
 
 ### Added

--- a/src/ai_config/adapters/claude.py
+++ b/src/ai_config/adapters/claude.py
@@ -6,6 +6,7 @@ This module shells out to the `claude` CLI to manage plugins and marketplaces.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -282,12 +283,18 @@ def update_marketplace(name: str | None = None) -> CommandResult:
 
 
 def clear_cache() -> CommandResult:
-    """Clear the plugin cache by removing the cache directory.
+    """Clear the active Claude profile's plugin cache directory.
 
     Returns:
         CommandResult indicating success or failure.
     """
-    cache_dir = Path.home() / ".claude" / "plugins" / "cache"
+    configured_dir = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    config_dir = (
+        Path(configured_dir).expanduser()
+        if configured_dir
+        else Path.home() / ".claude"
+    )
+    cache_dir = config_dir / "plugins" / "cache"
     if not cache_dir.exists():
         return CommandResult(
             success=True,

--- a/src/ai_config/adapters/claude.py
+++ b/src/ai_config/adapters/claude.py
@@ -289,11 +289,7 @@ def clear_cache() -> CommandResult:
         CommandResult indicating success or failure.
     """
     configured_dir = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
-    config_dir = (
-        Path(configured_dir).expanduser()
-        if configured_dir
-        else Path.home() / ".claude"
-    )
+    config_dir = Path(configured_dir).expanduser() if configured_dir else Path.home() / ".claude"
     cache_dir = config_dir / "plugins" / "cache"
     if not cache_dir.exists():
         return CommandResult(

--- a/tests/unit/test_adapters_claude.py
+++ b/tests/unit/test_adapters_claude.py
@@ -374,6 +374,25 @@ class TestClearCache:
         assert result.success is True
         assert not cache_dir.exists()
 
+    def test_cache_removed_from_configured_claude_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Removes only the cache for the configured Claude profile."""
+        default_cache = tmp_path / ".claude" / "plugins" / "cache"
+        configured_cache = tmp_path / ".claude-personal" / "plugins" / "cache"
+        default_cache.mkdir(parents=True)
+        configured_cache.mkdir(parents=True)
+        (default_cache / "work-plugin").write_text("work")
+        (configured_cache / "personal-plugin").write_text("personal")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude-personal"))
+
+        result = clear_cache()
+
+        assert result.success is True
+        assert default_cache.exists()
+        assert not configured_cache.exists()
+
 
 class TestGetByHelpers:
     """Tests for get_plugin_by_id and get_marketplace_by_name."""


### PR DESCRIPTION
## Why

Fresh syncs for alternate Claude profiles were clearing the default
`~/.claude` plugin cache instead of the profile selected by
`CLAUDE_CONFIG_DIR`. This left stale Personal plugin versions in place and could
make a valid source upgrade appear to be a prohibited downgrade.

## What changed

Cache clearing now resolves the active Claude config directory from
`CLAUDE_CONFIG_DIR`, with the existing `~/.claude` behavior as the fallback.
Regression coverage verifies that a Personal cache is removed while the default
profile cache remains untouched.

## Validation

The full unit suite passes (794 tests), along with focused Ruff and ty checks.
