### PR TITLE
Make sync converge across source stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Conversion source reads now use one fail-closed plugin-root containment boundary for manifests,
   components, skill assets, includes, Codex support files, and target-native files.
 - Current system specification, architecture overview, project-evolution timeline,
-  and six evidence-backed architecture decisions for plugin source, target-neutral
-  IR, target-native overrides, Codex packages, ownership, and observe-plan-apply sync.
+  and evidence-backed architecture decisions for plugin source, target-neutral IR,
+  target-native overrides, Codex packages, ownership, sync planning, shared resources,
+  and bounded convergence stages.
 
 ### Changed
 
-- Conversion cache version 8 invalidates content entries after expanding source hashing while
-  preserving validated tracked Codex and Pi output roots for cleanup discovery.
+- Conversion cache version 9 keys entries by configured plugin selector instead of physical source
+  path, records source provenance, and invalidates legacy content entries while preserving validated
+  tracked Codex and Pi output roots for cleanup discovery.
+- Sync may apply one immutable Claude prerequisite plan and one separately observed conversion plan,
+  allowing fresh remote plugins to install and convert in one bounded invocation without apply-time
+  replanning or recursive retries.
 - Accept the repository-tested Codex plugin lifecycle schema/version contract through 0.149.x;
   captured auth-free real-runtime package and public-sync probes now extend through 0.149.0.
 
@@ -30,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync source hashing now accepts the repository-standard `CLAUDE.md -> AGENTS.md`
   sibling mirror while continuing to reject every other symlink, allowing safe local
   plugin marketplaces to participate in immutable observe-plan-apply snapshots.
+- Configured local marketplaces remain conversion-source authorities after Claude installation, so
+  fresh isolated `sync --force --verify` no longer reports false Codex refresh drift or converts a
+  stale installed copy.
+- JSON and text sync skip verification consistently after apply failure; JSON reports verification
+  as requested but not performed.
 - Shared-resource reports now retain per-Markdown rewrite evidence through target-native
   overrides, so additive rewrite totals describe only the final converter-emitted projection.
 - Claude cache clearing now respects `CLAUDE_CONFIG_DIR`, so fresh syncs for

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Relative local marketplace paths and conversion output paths are resolved from t
 | Apply and verify sync | `ai-config sync --verify` | Installs/uninstalls plugins and runs configured conversion. |
 | See installed state | `ai-config status` | Add `--verify` to compare against config. |
 | Validate config or output | `ai-config doctor` | Use `--target codex`, `--target cursor`, `--target opencode`, or `--target pi` for converted output. |
-| Rebuild stale output | `ai-config sync --fresh` | Clears cache and re-converts everything. |
+| Rebuild stale output | `ai-config sync --fresh` | Clears Claude's plugin cache and reconverts configured outputs while preserving target homes and ownership ledgers. |
 | Re-run conversion only | `ai-config sync --force-convert` | Useful after changing conversion targets. |
 | Develop local plugins | `ai-config watch` | Add `--dry-run` if you only want file-change reports. |
 
@@ -168,7 +168,7 @@ just check
 ai-config sync --dry-run
 ```
 
-**DO use `--fresh` when cached plugins or converted output look stale, NOT hand-delete random target files first, BECAUSE sync knows the cache and conversion state.**
+**DO use `--fresh` when Claude's cached plugins or converted output look stale, NOT hand-delete random target files first, BECAUSE sync preserves and reconciles its target ownership state.**
 
 ```bash
 ai-config sync --fresh

--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,8 @@ ai-config is a declarative manager for Claude Code plugin marketplaces and insta
 ## Requirements
 
 - The system MUST accept config version 1 with `claude` as its top-level target type and validate marketplace, plugin, scope, and conversion settings before mutation.
-- `sync` MUST observe runtime and source state, create an ordered plan, validate its preconditions, and apply only that plan.
+- `sync` MUST observe runtime and source state, create an ordered plan, validate its preconditions, and apply only that plan. It MAY cross one explicit prerequisite barrier by applying an immutable Claude-only plan, re-observing once, and applying a separately validated conversion-only plan; it MUST NOT recursively sync until quiet or derive replacement actions during apply.
+- A configured local marketplace MUST remain the conversion-source authority after Claude installation. Missing or unsafe configured local sources MUST remain unavailable rather than falling back to Claude's installed cache. Remote and marketplace-less sources MAY use safely observed installed paths.
 - A dry run MUST avoid state-changing runtime calls, filesystem writes, cache writes, and ownership writes, except for an explicitly requested `convert --report PATH` artifact.
 - The conversion pipeline MUST parse a Claude Code plugin into a target-neutral IR before invoking an independent target emitter.
 - Every source byte consumed by conversion MUST be read through a fail-closed plugin-root containment boundary; absolute/traversing paths, resolved escape, final or in-root ancestor symlinks, and non-regular files MUST NOT be read or emitted. Sync source hashing MAY retain metadata for the exact repository context mirror `CLAUDE.md -> AGENTS.md` when both entries are siblings and the target is a no-follow regular file; hashing MUST NOT read through that link, and every other symlink shape MUST make the source unreadable. Sync MUST hash the complete safely readable tree plus validated mirror metadata and recheck that digest as a precondition before conversion; standalone `convert` does not compute a source digest, and digesting plus conversion are not one immutable filesystem snapshot.
@@ -29,6 +30,8 @@ ai-config is a declarative manager for Claude Code plugin marketplaces and insta
 - Cursor and OpenCode conversion MUST remain path-contained, but callers MUST NOT interpret path containment as proof that a pre-existing file is ai-config-owned.
 - `status` MUST report installed state without requiring config; config drift comparison MUST occur only when config or verification is requested.
 - `update` MUST operate on named installed plugins or all installed plugins and MUST NOT imply config reconciliation.
+- The conversion cache MUST use configured plugin selectors and conversion settings as logical identity while retaining source provenance, physical path, source digest, and generated Codex digest as cache-hit observations. Cache migration MUST preserve only validated tracked output roots needed for ownership cleanup.
+- `sync --verify` MUST perform its read-only verification plan only after every requested apply stage succeeds. An intentionally empty isolated `CODEX_HOME` is a valid initial state.
 - The system SHOULD make unchanged sync and conversion runs no-ops.
 - A caller MAY request project or user conversion scope and MAY provide an explicit output directory.
 
@@ -50,7 +53,7 @@ ai-config is a declarative manager for Claude Code plugin marketplaces and insta
 - The same materialized sync plan authorizes dry-run rendering and real execution.
 - Target emitters do not mutate the parsed plugin IR or another target's result.
 - Shared include records in IR are immutable, and one pure target-neutral projection supplies all target emitters without rereading include sources.
-- Marketplace actions precede dependent Claude plugin actions, and conversion actions follow them.
+- Marketplace actions precede dependent Claude plugin actions, and conversion actions follow them. A staged conversion plan contains no marketplace or plugin action; unmet prerequisites block that stage.
 - Failed or stale preconditions prevent the affected mutation and prevent unsupported cache or ownership checkpoints.
 - Missing or temporarily unavailable sources do not authorize deletion of their prior proven-owned output.
 - Generated Codex and Pi cleanup never crosses the validated ownership root.
@@ -64,6 +67,7 @@ ai-config is a declarative manager for Claude Code plugin marketplaces and insta
 - `uv run pytest tests/unit/ -v` passes the unit contract for config parsing, planning, conversion, target validation, lifecycle, and ownership behavior.
 - `uv run mkdocs build --strict` resolves and renders the public documentation.
 - Docker E2E lanes exercise supported tool surfaces, while isolated Codex and Pi probes verify real lifecycle behavior without using the caller's runtime homes or credentials.
-- `sync --dry-run` and the corresponding real sync expose the same planned action ordering for unchanged evidence.
+- `sync --dry-run` and the corresponding first real stage expose the same planned action ordering for unchanged evidence; unavailable remote conversion is reported as deferred rather than speculated before installation.
+- A fresh isolated local-marketplace `sync --force --verify` converges in one invocation without false Codex refresh drift, and a fresh remote source requires at most one Claude prerequisite apply plus one conversion apply.
 - Repeated sync converges without mutation, and tamper/removal tests prove cleanup stays within recorded target ownership.
 - Shared-resource fixtures prove two consumers receive independent byte-exact copies for all four emitters, with no build metadata or unresolved Claude root placeholder.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,6 +24,7 @@ MkDocs owns this directory's public structure. Keep `docs/index.md` as the human
 | `adr/0005-proven-output-ownership.md` | Why destructive cleanup requires target-specific ownership proof. |
 | `adr/0006-observe-plan-apply-sync.md` | Why sync separates observation, planning, and application. |
 | `adr/0007-materialize-shared-skill-resources.md` | Why shared plugin files are materialized into self-contained generated skills. |
+| `adr/0008-bounded-sync-convergence-stages.md` | Why fresh remote sync uses at most one prerequisite plan and one conversion plan. |
 
 ## Entry point
 

--- a/docs/adr/0006-observe-plan-apply-sync.md
+++ b/docs/adr/0006-observe-plan-apply-sync.md
@@ -15,4 +15,6 @@ Sync first observes desired configuration, runtime state, source state, cache, a
 
 ## Consequences
 
-Dry-run and real execution share one authorization artifact, and target-specific planners remain responsible for their domains. The design adds explicit snapshot and action records, but makes state drift, partial progress, and checkpoint eligibility observable. Real `--fresh` cache clearing remains outside the pure transform because it changes subsequent observation; fresh dry-run remains mutation-free.
+Dry-run and each real execution stage share an immutable authorization artifact, and target-specific planners remain responsible for their domains. The design adds explicit snapshot and action records, but makes state drift, partial progress, and checkpoint eligibility observable. Real `--fresh` cache clearing remains outside the pure transform because it changes subsequent observation; fresh dry-run remains mutation-free.
+
+[ADR 0008](0008-bounded-sync-convergence-stages.md) permits one explicit re-observation barrier after a successfully applied Claude prerequisite plan. It does not permit apply-time replanning: the conversion stage receives a new snapshot and separately validated immutable plan, and the operation remains bounded.

--- a/docs/adr/0008-bounded-sync-convergence-stages.md
+++ b/docs/adr/0008-bounded-sync-convergence-stages.md
@@ -1,0 +1,34 @@
+# Bound sync convergence across prerequisite and conversion stages
+
+Status: Accepted
+Date: 2026-08-21
+
+## Context
+
+A configured remote Claude plugin may not have a readable conversion source in a fresh environment. The source becomes available only after Claude registers its marketplace and installs the plugin. A single immutable plan cannot both authorize that prerequisite mutation and precompute conversion artifacts from bytes that do not yet exist.
+
+Configured local marketplaces have a different authority contract: their configured source tree is already inspectable and must not be replaced by Claude's installed cache merely because installation occurred. Treating either installed paths or repeated whole-sync execution as a universal fallback produced path-sensitive cache misses and made fresh isolated verification require another invocation.
+
+ADR 0006 requires observation, immutable planning, precondition checks, and exact-plan execution. The convergence workflow must preserve those properties while acknowledging a real prerequisite boundary.
+
+## Decision
+
+Sync remains bounded and plan-driven, but may use two separately observed immutable plans:
+
+1. The initial observation materializes a complete plan.
+2. If an enabled non-local source is unavailable and the plan contains Claude marketplace or plugin prerequisites, sync projects and applies only that exact Claude prerequisite prefix.
+3. After successful prerequisite application, sync performs one explicit re-observation and materializes a new plan.
+4. The second plan is projected to conversion actions only. If it still requires any Claude marketplace or plugin action, conversion is blocked rather than retrying the prerequisite stage.
+5. Optional verification performs one final read-only plan only after the aggregate apply succeeds.
+
+Sync never recursively runs until quiet and never replans from inside an executor. Each applied stage has its own runtime, source, cache, and ownership snapshot and consumes only its materialized actions and target batches.
+
+Configured local marketplaces are strict conversion-source authorities. Missing or unsafe configured local sources remain unavailable and never trigger installed-cache fallback or staged re-observation. Remote and marketplace-less plugins may use safely observed installed sources.
+
+A dry run does not cross the prerequisite boundary. It reports exact Claude prerequisite actions and deferred source diagnostics without speculating about conversion artifacts that cannot yet be observed.
+
+## Consequences
+
+Fresh remote bootstrap can converge Claude installation and target conversion in one bounded invocation when the prerequisite succeeds and the source becomes readable. If post-install parsing or conversion fails, completed Claude actions remain visible, target ownership is retained according to existing rules, and sync exits non-zero without verification. If the second observation still needs Claude reconciliation, the user must correct the runtime state or retry; the same invocation will not reinstall repeatedly.
+
+Conversion cache identity is the configured plugin selector plus conversion signature. Physical source path, provenance, source digest, and generated Codex digest remain observations required for a cache hit. Legacy path-keyed entries are discarded while validated tracked output roots remain available for ownership cleanup.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,5 +11,6 @@ These records explain lasting choices whose rationale is established in reposito
 | [Require proven ownership for destructive cleanup](0005-proven-output-ownership.md) | Accepted | 2026-07-26 |
 | [Separate sync observation, planning, and application](0006-observe-plan-apply-sync.md) | Accepted | 2026-07-29 |
 | [Materialize shared plugin resources into generated skills](0007-materialize-shared-skill-resources.md) | Accepted | 2026-08-20 |
+| [Bound sync convergence across prerequisite and conversion stages](0008-bounded-sync-convergence-stages.md) | Accepted | 2026-08-21 |
 
 Retrospective records use the date the decision entered `main`, not the date this index was written.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,9 +31,11 @@ flowchart LR
 
 ## Sync flow
 
-Marketplace actions precede dependent Claude plugin actions. Conversion follows Claude reconciliation because conversion sources may come from installed or local marketplace plugins. The executor rechecks observed preconditions before mutation. It records completed and failed actions separately and commits cache or ownership checkpoints only where the plan permits them.
+Marketplace actions precede dependent Claude plugin actions. Configured local marketplaces remain the strict conversion-source authority after installation; remote and marketplace-less plugins may use safely observed installed sources.
 
-`--dry-run` renders the same materialized plan without runtime, cache, ownership, or filesystem mutation, except for a report explicitly requested with `convert --report PATH`. A real `--fresh` clears Claude's cache before observation; a fresh dry-run does not, because its mutation-free contract is stronger than simulating that altered observation.
+When a fresh remote source does not exist until Claude installs it, the public operation coordinates two bounded immutable plans. It first applies only the exact Claude prerequisite prefix, re-observes once, then applies a conversion-only projection of the second plan. The second plan is blocked if it still requires Claude reconciliation. Executors never replan, and sync never recursively runs until quiet. Each executor rechecks its plan's runtime, source, cache, and ownership preconditions, records completed and failed actions separately, and commits checkpoints only where that plan permits them.
+
+`--dry-run` renders the initial materialized plan without runtime, cache, ownership, or filesystem mutation, except for a report explicitly requested with `convert --report PATH`. Deferred remote conversion remains explicit because dry-run cannot inspect a source that installation has not materialized. A real `--fresh` clears Claude's plugin cache before observation and forces configured conversion; it does not clear target homes or ownership ledgers. A fresh dry-run does not clear anything because its mutation-free contract is stronger than simulating that altered observation. Optional verification performs one final read-only plan only after every apply stage succeeds.
 
 ## Conversion flow
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,7 +64,7 @@ ai-config sync
 |--------|-------------|
 | `-c, --config PATH` | Path to config file |
 | `--dry-run` | Show what would change without doing it |
-| `--fresh`, `--force` | Full rebuild: clear cache + reconvert everything |
+| `--fresh`, `--force` | Clear Claude's plugin cache and reconvert configured outputs; preserve target homes and ownership ledgers |
 | `--force-convert` | Reconvert only (without clearing plugin cache) |
 | `--verify` | Verify sync state after completion |
 | `--json` | Output planned/completed actions and reasons as JSON |

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -189,16 +189,31 @@ ai-config doctor --target all ./output-dir
 ai-config sync --force-convert
 ```
 
-Sync hashes plugin source, conversion settings, and owned generated marketplace bytes. A cache hit
-is accepted only while the package and marketplace still exist without symlinks and match the saved
-fingerprint, so normal sync repairs deleted or tampered output. Dry-run and JSON output distinguish
-planned, completed, and failed actions. `status --config ... --json` exits non-zero when lifecycle
-planning finds a non-no-op action or an inspection error.
+Sync keys conversion cache entries by configured plugin selector and conversion settings. Source
+provenance, physical path, complete safe source digest, and owned generated Codex bytes remain
+required observations for a cache hit. A changed source path refreshes output because target files
+may contain resolved plugin-root paths. Legacy path-keyed entries are discarded while validated
+tracked output roots remain available for ownership cleanup. Normal sync therefore repairs deleted
+or tampered output without treating an incidental path as logical plugin identity.
 
-Configured sources are tracked separately as desired, temporarily unavailable, or disabled. A
-temporarily unavailable source retains prior ownership; a disabled/removed source is cleaned up.
-Removing or disabling the Codex target also reconciles prior owned roots, including a prior custom
-`output_dir` recorded in the conversion cache.
+Configured local marketplaces are strict conversion-source authorities, including after Claude
+installs a cached copy. If that configured tree is missing or unsafe, sync retains prior ownership
+and reports it unavailable rather than converting stale installed bytes. Remote and
+marketplace-less plugins may use safely observed installed sources.
+
+A fresh remote plugin may require Claude installation before its source can be inspected. Real sync
+applies one immutable Claude prerequisite plan, re-observes once, and then applies a separately
+validated conversion-only plan. It never retries Claude actions or recursively syncs until quiet.
+Dry-run reports the exact prerequisite actions and deferred source without speculating about the
+second stage. If post-install parsing or conversion fails, completed Claude actions remain visible,
+conversion exits non-zero, and verification is skipped.
+
+Dry-run and JSON output distinguish planned, completed, and failed actions. `sync --verify` performs
+one read-only verification only after all apply stages succeed; an empty isolated `CODEX_HOME` is a
+supported initial state. `status --config ... --json` exits non-zero when lifecycle planning finds a
+non-no-op action or an inspection error. A temporarily unavailable source retains prior ownership;
+a disabled/removed source is cleaned up. Removing or disabling the Codex target also reconciles
+prior owned roots, including a prior custom `output_dir` recorded in the conversion cache.
 
 Every Codex subprocess has a finite timeout. On POSIX, each command starts in a separate process
 group; after a bounded SIGTERM grace period, timeout cleanup inspects and kills any remaining group

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Proven output ownership: adr/0005-proven-output-ownership.md
       - Observe-plan-apply sync: adr/0006-observe-plan-apply-sync.md
       - Shared skill resources: adr/0007-materialize-shared-skill-resources.md
+      - Bounded sync convergence: adr/0008-bounded-sync-convergence-stages.md
 
 extra:
   social:

--- a/src/ai_config/cli.py
+++ b/src/ai_config/cli.py
@@ -87,7 +87,7 @@ def main() -> None:
     "  ai-config sync --dry-run --json Machine-readable actions and reasons\n"
     "  ai-config sync                  Apply changes\n"
     "  ai-config sync --verify         Apply and verify result\n"
-    "  ai-config sync --force          Full rebuild: clear cache + reconvert all\n"
+    "  ai-config sync --force          Clear Claude plugin cache + reconvert all\n"
     "  ai-config sync --force-convert   Reconvert only (skip cache clear)",
 )
 @click.option(
@@ -99,7 +99,10 @@ def main() -> None:
 )
 @click.option("--dry-run", is_flag=True, help="Show what would be done without making changes.")
 @click.option(
-    "--fresh", "--force", is_flag=True, help="Full clean rebuild: clear cache + reconvert all."
+    "--fresh",
+    "--force",
+    is_flag=True,
+    help="Clear Claude's plugin cache and reconvert all configured outputs.",
 )
 @click.option(
     "--force-convert",
@@ -158,8 +161,14 @@ def sync(
             progress.add_task("Syncing plugins...", total=None)
             results = sync_config(config, dry_run=dry_run, fresh=fresh, force_convert=force_convert)
 
+    apply_succeeded = all(
+        result.success and not result.actions_failed and not result.errors
+        for result in results.values()
+    )
+
     if as_json:
-        discrepancies = verify_sync(config) if verify and not dry_run else []
+        verification_performed = verify and not dry_run and apply_succeeded
+        discrepancies = verify_sync(config) if verification_performed else []
         output = {
             "dry_run": dry_run,
             "targets": {
@@ -202,7 +211,7 @@ def sync(
             },
             "verification": {
                 "requested": verify,
-                "performed": verify and not dry_run,
+                "performed": verification_performed,
                 "discrepancies": discrepancies,
             },
         }

--- a/src/ai_config/operations.py
+++ b/src/ai_config/operations.py
@@ -6,8 +6,10 @@ from ai_config.adapters import claude
 from ai_config.sync_orchestration import (
     apply_sync_plan,
     build_sync_plan,
+    requires_source_reobservation,
     sync_result_from_execution,
 )
+from ai_config.sync_pipeline import conversion_stage_plan, prerequisite_sync_plan
 from ai_config.types import (
     AIConfig,
     PluginStatus,
@@ -42,11 +44,29 @@ def sync_target(
     plan = build_sync_plan(target, force_convert=force_convert)
     if dry_run:
         plan_errors = [item.message for item in (*plan.diagnostics, *plan.reported_diagnostics)]
+        rendered_plan = (
+            prerequisite_sync_plan(plan) if requires_source_reobservation(plan) else plan
+        )
         result = SyncResult(
             success=not plan_errors,
-            actions_taken=[item.action for item in plan.actions],
+            actions_taken=[item.action for item in rendered_plan.actions],
             errors=plan_errors,
         )
+    elif requires_source_reobservation(plan):
+        prerequisite = sync_result_from_execution(apply_sync_plan(prerequisite_sync_plan(plan)))
+        if not prerequisite.success or prerequisite.actions_failed or prerequisite.errors:
+            result = prerequisite
+        else:
+            reobserved = build_sync_plan(target, force_convert=force_convert)
+            converged = sync_result_from_execution(
+                apply_sync_plan(conversion_stage_plan(reobserved))
+            )
+            result = SyncResult(
+                success=converged.success,
+                actions_taken=[*prerequisite.actions_taken, *converged.actions_taken],
+                actions_failed=[*prerequisite.actions_failed, *converged.actions_failed],
+                errors=[*prerequisite.errors, *converged.errors],
+            )
     else:
         result = sync_result_from_execution(apply_sync_plan(plan))
     if fresh_errors:
@@ -66,7 +86,7 @@ def sync_config(
     Args:
         config: Configuration to sync.
         dry_run: If True, only report what would be done.
-        fresh: If True, clear cache before syncing.
+        fresh: If True, clear Claude's plugin cache before syncing.
         force_convert: If True, bypass conversion hash cache.
 
     Returns:

--- a/src/ai_config/sync_conversion.py
+++ b/src/ai_config/sync_conversion.py
@@ -37,6 +37,7 @@ from ai_config.sync_pipeline import (
     EmittedTargetBatch,
     PiRootPlan,
     PlannedCheckpoint,
+    ResolvedPluginSource,
     TargetActionBatch,
 )
 from ai_config.types import (
@@ -156,7 +157,7 @@ def _plan_conversion_pipeline(
     force_convert: bool,
     installed_plugins: tuple[claude.InstalledPlugin, ...],
     cache_snapshot: dict,
-    resolved_sources: dict[str, Path],
+    resolved_sources: dict[str, ResolvedPluginSource],
     planned_batches: list[TargetActionBatch],
     preflight_summary: dict[str, tuple[str, ...]],
     planned_emissions: list[EmittedTargetBatch],
@@ -263,7 +264,8 @@ def _plan_conversion_pipeline(
                 continue
 
             installed = installed_by_id.get(plugin_config.id)
-            plugin_path = resolved_sources.get(plugin_config.id)
+            resolved_source = resolved_sources.get(plugin_config.id)
+            plugin_path = resolved_source.path if resolved_source is not None else None
             if plugin_path is None:
                 if codex_enabled:
                     retained_codex_ids.add(configured_codex_id)
@@ -403,13 +405,19 @@ def _plan_conversion_pipeline(
     candidates_to_convert: list[tuple[_ConversionCandidate, str | None]] = []
     candidate_hashes: dict[str, str | None] = {}
     for candidate in candidates:
-        plugin_hash = state.compute_plugin_hash(candidate.plugin_path)
+        source = resolved_sources[candidate.config_id]
+        plugin_hash = source.digest
         candidate_hashes[candidate.config_id] = plugin_hash
         cache_valid = False
         if not force_convert and plugin_hash is not None:
-            signature_map = cache_entries.get(str(candidate.plugin_path))
+            signature_map = cache_entries.get(candidate.config_id)
             cached = signature_map.get(signature) if isinstance(signature_map, dict) else None
-            cache_valid = isinstance(cached, dict) and cached.get("hash") == plugin_hash
+            cache_valid = (
+                isinstance(cached, dict)
+                and cached.get("hash") == plugin_hash
+                and cached.get("source_path") == str(candidate.plugin_path)
+                and cached.get("source_provenance") == source.provenance
+            )
             if cache_valid and candidate.codex_spec is not None:
                 if not isinstance(cached, dict):
                     cache_valid = False
@@ -576,11 +584,12 @@ def _plan_conversion_pipeline(
             cache_dirty=cache_dirty,
             candidates=tuple(
                 ConversionCandidatePlan(
-                    candidate.config_id,
-                    candidate.plugin_path,
-                    candidate_hashes.get(candidate.config_id),
-                    candidate.config_id in refresh_ids,
-                    candidate.codex_spec,
+                    source_plugin_id=candidate.config_id,
+                    source_path=candidate.plugin_path,
+                    source_digest=candidate_hashes.get(candidate.config_id),
+                    source_provenance=resolved_sources[candidate.config_id].provenance,
+                    refresh=candidate.config_id in refresh_ids,
+                    codex_spec=candidate.codex_spec,
                 )
                 for candidate in candidates
             ),
@@ -604,7 +613,7 @@ def plan_conversions(
     force_convert: bool,
     installed_plugins: tuple[claude.InstalledPlugin, ...],
     cache_snapshot: dict,
-    resolved_sources: dict[str, Path],
+    resolved_sources: dict[str, ResolvedPluginSource],
 ) -> ConversionPlanningResult:
     """Preflight conversion and materialize all emitted and lifecycle decisions."""
     target_batches: list[TargetActionBatch] = []
@@ -797,12 +806,14 @@ def apply_conversion_plan(
                 continue
             refreshed_codex_ids.add(candidate.codex_spec.plugin_id)
         if candidate.source_digest is not None:
-            signature_map = cache_entries.setdefault(str(candidate.source_path), {})
+            signature_map = cache_entries.setdefault(candidate.source_plugin_id, {})
             if not isinstance(signature_map, dict):
                 signature_map = {}
-                cache_entries[str(candidate.source_path)] = signature_map
+                cache_entries[candidate.source_plugin_id] = signature_map
             cache_value: dict[str, str] = {
                 "hash": candidate.source_digest,
+                "source_path": str(candidate.source_path),
+                "source_provenance": candidate.source_provenance,
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
             if candidate.codex_spec is not None:

--- a/src/ai_config/sync_orchestration.py
+++ b/src/ai_config/sync_orchestration.py
@@ -23,6 +23,7 @@ from ai_config.sync_pipeline import (
     ResolvedPluginSource,
     RuntimeSnapshot,
     SourceBatch,
+    SourceProvenance,
     SyncPlan,
     TargetActionBatch,
     UnavailablePluginSource,
@@ -79,20 +80,51 @@ def _source_batch(
         if not plugin.enabled:
             continue
         installed = installed_by_id.get(plugin.id)
+        configured_marketplace = (
+            config.marketplaces.get(plugin.marketplace) if plugin.marketplace is not None else None
+        )
+        configured_local = (
+            configured_marketplace is not None
+            and configured_marketplace.source == PluginSource.LOCAL
+        )
         path = state.resolve_plugin_conversion_path(config, plugin, installed)
-        if (path is None or not path.is_dir()) and plugin.marketplace is not None:
+        provenance: SourceProvenance = (
+            "configured_local" if configured_local else "installed_plugin"
+        )
+        if (
+            (path is None or not path.is_dir())
+            and plugin.marketplace is not None
+            and not configured_local
+        ):
             observed_marketplace = marketplaces_by_name.get(plugin.marketplace)
             if observed_marketplace is not None and observed_marketplace.install_location:
                 path = state.resolve_local_marketplace_plugin_path(
                     Path(observed_marketplace.install_location), plugin.plugin_name
                 )
+                if path is not None:
+                    provenance = "observed_remote_marketplace"
         if path is not None and path.is_dir():
-            resolved.append(ResolvedPluginSource(plugin.id, path, state.compute_plugin_hash(path)))
+            resolved.append(
+                ResolvedPluginSource(
+                    plugin.id,
+                    path,
+                    state.compute_plugin_hash(path),
+                    provenance,
+                )
+            )
         else:
+            unavailable_provenance: SourceProvenance = (
+                "unavailable_configured_local"
+                if configured_local
+                else "unavailable_remote"
+                if plugin.marketplace is not None
+                else "unavailable_marketplace_less"
+            )
             unavailable.append(
                 UnavailablePluginSource(
                     plugin.id,
                     installed.install_path if installed is not None else "<unavailable>",
+                    unavailable_provenance,
                 )
             )
     return SourceBatch(resolved=tuple(resolved), unavailable=tuple(unavailable))
@@ -109,6 +141,23 @@ def build_sync_plan(target: TargetConfig, *, force_convert: bool = False) -> Syn
     plugins, plugin_errors = claude.list_installed_plugins()
     installed_plugins = tuple(sorted(plugins, key=lambda item: item.id))
     observation_errors = [*marketplace_errors, *plugin_errors]
+    configured_ids = [item.id for item in target.config.plugins]
+    duplicate_configured = sorted(
+        plugin_id for plugin_id in set(configured_ids) if configured_ids.count(plugin_id) > 1
+    )
+    installed_ids = [item.id for item in installed_plugins]
+    duplicate_installed = sorted(
+        plugin_id for plugin_id in set(installed_ids) if installed_ids.count(plugin_id) > 1
+    )
+    if duplicate_configured:
+        observation_errors.append(
+            "Duplicate configured plugin selectors: " + ", ".join(duplicate_configured)
+        )
+    if duplicate_installed:
+        observation_errors.append(
+            "Claude reported duplicate installed plugin selectors: "
+            + ", ".join(duplicate_installed)
+        )
     cache: dict = {}
     codex_roots: tuple[Path, ...] = ()
     pi_roots: tuple[Path, ...] = ()
@@ -164,7 +213,7 @@ def build_sync_plan(target: TargetConfig, *, force_convert: bool = False) -> Syn
             force_convert=force_convert,
             installed_plugins=installed_plugins,
             cache_snapshot=cache,
-            resolved_sources={item.config_id: item.path for item in sources.resolved},
+            resolved_sources={item.config_id: item for item in sources.resolved},
         )
         conversion_plan = conversion_result.plan
         conversion_actions = conversion_result.actions
@@ -214,6 +263,22 @@ def build_sync_plan(target: TargetConfig, *, force_convert: bool = False) -> Syn
         target_batches=target_batches,
         checkpoints=checkpoints,
         conversion=conversion_plan,
+    )
+
+
+def requires_source_reobservation(plan: SyncPlan) -> bool:
+    """Return whether one Claude apply may reveal a deferred non-local source."""
+    conversion = plan.desired.conversion
+    eligible = any(
+        item.provenance in {"unavailable_remote", "unavailable_marketplace_less"}
+        for item in plan.sources.unavailable
+    )
+    return bool(
+        conversion is not None
+        and conversion.enabled
+        and eligible
+        and plan.reported_diagnostics
+        and any(item.phase in {"marketplace", "plugin"} for item in plan.actions)
     )
 
 

--- a/src/ai_config/sync_pipeline.py
+++ b/src/ai_config/sync_pipeline.py
@@ -431,6 +431,7 @@ def prerequisite_sync_plan(plan: SyncPlan) -> SyncPlan:
             plan,
             sources=sources,
             actions=tuple(item for item in plan.actions if item.phase != "conversion"),
+            diagnostics=tuple(item for item in plan.diagnostics if item.phase != "conversion"),
             reported_diagnostics=(),
             target_batches=(),
             checkpoints=(),

--- a/src/ai_config/sync_pipeline.py
+++ b/src/ai_config/sync_pipeline.py
@@ -22,6 +22,14 @@ from ai_config.types import (
 )
 
 SyncPhase = Literal["marketplace", "plugin", "conversion"]
+SourceProvenance = Literal[
+    "configured_local",
+    "installed_plugin",
+    "observed_remote_marketplace",
+    "unavailable_configured_local",
+    "unavailable_remote",
+    "unavailable_marketplace_less",
+]
 
 
 @dataclass(frozen=True)
@@ -90,7 +98,8 @@ class ResolvedPluginSource:
 
     config_id: str
     path: Path
-    digest: str | None = None
+    digest: str | None
+    provenance: SourceProvenance
 
 
 @dataclass(frozen=True)
@@ -99,6 +108,7 @@ class UnavailablePluginSource:
 
     config_id: str
     install_path: str
+    provenance: SourceProvenance
 
 
 @dataclass(frozen=True)
@@ -197,6 +207,7 @@ class ConversionCandidatePlan:
     source_plugin_id: str
     source_path: Path
     source_digest: str | None
+    source_provenance: SourceProvenance
     refresh: bool
     codex_spec: CodexPackageSpec | None = None
 
@@ -336,6 +347,23 @@ def validate_sync_plan(plan: SyncPlan) -> tuple[BlockingDiagnostic, ...]:
             BlockingDiagnostic("conversion", "Materialized conversion plan is inconsistent")
         )
 
+    if plan.conversion is not None:
+        observed_sources = {item.config_id: item for item in plan.sources.resolved}
+        for candidate in plan.conversion.candidates:
+            observed = observed_sources.get(candidate.source_plugin_id)
+            if observed is None or (
+                observed.path != candidate.source_path
+                or observed.digest != candidate.source_digest
+                or observed.provenance != candidate.source_provenance
+            ):
+                diagnostics.append(
+                    BlockingDiagnostic(
+                        "conversion",
+                        f"Conversion candidate source snapshot is inconsistent for "
+                        f"{candidate.source_plugin_id}",
+                    )
+                )
+
     seen_emissions: set[tuple[str, str]] = set()
     for batch in plan.sources.emitted.batches:
         key = (batch.source_plugin_id, batch.target)
@@ -389,6 +417,48 @@ def materialize_plan_validation(plan: SyncPlan) -> SyncPlan:
     if not validation:
         return plan
     return replace(plan, diagnostics=(*plan.diagnostics, *validation))
+
+
+def prerequisite_sync_plan(plan: SyncPlan) -> SyncPlan:
+    """Project an immutable plan to its exact Claude prerequisite prefix."""
+    sources = replace(
+        plan.sources,
+        parsed=ParsedPluginBatch(),
+        emitted=EmittedArtifactBatch(),
+    )
+    return materialize_plan_validation(
+        replace(
+            plan,
+            sources=sources,
+            actions=tuple(item for item in plan.actions if item.phase != "conversion"),
+            reported_diagnostics=(),
+            target_batches=(),
+            checkpoints=(),
+            conversion=None,
+        )
+    )
+
+
+def conversion_stage_plan(plan: SyncPlan) -> SyncPlan:
+    """Project a re-observed plan to conversion only, blocking unmet prerequisites."""
+    prerequisite_actions = tuple(item for item in plan.actions if item.phase != "conversion")
+    diagnostics = plan.diagnostics
+    if prerequisite_actions:
+        diagnostics = (
+            *diagnostics,
+            BlockingDiagnostic(
+                "conversion",
+                "Claude prerequisites did not converge after one apply; "
+                "no conversion action was executed",
+            ),
+        )
+    return materialize_plan_validation(
+        replace(
+            plan,
+            actions=tuple(item for item in plan.actions if item.phase == "conversion"),
+            diagnostics=diagnostics,
+        )
+    )
 
 
 def plan_sync(

--- a/src/ai_config/sync_state.py
+++ b/src/ai_config/sync_state.py
@@ -18,7 +18,7 @@ from ai_config.pi_ownership import load_pi_ownership
 from ai_config.source_safety import ContainedSource, SourceSafetyError
 from ai_config.types import ClaudeTargetConfig, ConversionConfig, PluginConfig, PluginSource
 
-_CONVERSION_CACHE_VERSION = 8
+_CONVERSION_CACHE_VERSION = 9
 
 
 def conversion_cache_path() -> Path:
@@ -58,6 +58,40 @@ def _validated_cached_output_dirs(raw: dict, key: str, cache_path: Path) -> list
     return sorted(resolved)
 
 
+def _validate_cache_entries(
+    entries: object, cache_path: Path
+) -> dict[str, dict[str, dict[str, object]]]:
+    message = f"Invalid conversion cache entries at {cache_path}; clear it and retry"
+    if not isinstance(entries, dict):
+        raise ValueError(message)
+    validated: dict[str, dict[str, dict[str, object]]] = {}
+    for selector, signatures in entries.items():
+        if not isinstance(selector, str) or not selector or not isinstance(signatures, dict):
+            raise ValueError(message)
+        validated_signatures: dict[str, dict[str, object]] = {}
+        for signature, value in signatures.items():
+            if not isinstance(signature, str) or not isinstance(value, dict):
+                raise ValueError(message)
+            value_map = {str(key): item for key, item in value.items()}
+            try:
+                settings = json.loads(signature)
+            except json.JSONDecodeError as error:
+                raise ValueError(message) from error
+            if not isinstance(settings, dict):
+                raise ValueError(message)
+            required = ("hash", "source_path", "source_provenance", "updated_at")
+            if any(
+                not isinstance(value_map.get(key), str) or not value_map[key] for key in required
+            ):
+                raise ValueError(message)
+            output_hash = value_map.get("codex_output_hash")
+            if output_hash is not None and (not isinstance(output_hash, str) or not output_hash):
+                raise ValueError(message)
+            validated_signatures[signature] = value_map
+        validated[selector] = validated_signatures
+    return validated
+
+
 def load_conversion_cache() -> dict:
     cache_path = conversion_cache_path()
     empty = {
@@ -78,8 +112,9 @@ def load_conversion_cache() -> dict:
         raise ValueError(f"Invalid conversion cache object at {cache_path}; clear it and retry")
     codex_dirs = _validated_cached_output_dirs(raw, "codex_output_dirs", cache_path)
     pi_dirs = _validated_cached_output_dirs(raw, "pi_output_dirs", cache_path)
-    if raw.get("version") == 7:
-        # Content hashes changed in v8, but ownership cleanup still needs prior custom roots.
+    if raw.get("version") in {7, 8}:
+        # v8 content hashes remain valid, but v9 keys entries by configured plugin identity
+        # instead of an incidental source path. Ownership cleanup still needs prior roots.
         return {
             "version": _CONVERSION_CACHE_VERSION,
             "entries": {},
@@ -88,8 +123,7 @@ def load_conversion_cache() -> dict:
         }
     if raw.get("version") != _CONVERSION_CACHE_VERSION:
         return empty
-    if not isinstance(raw.get("entries"), dict):
-        raise ValueError(f"Invalid conversion cache entries at {cache_path}; clear it and retry")
+    raw["entries"] = _validate_cache_entries(raw.get("entries"), cache_path)
     raw["codex_output_dirs"] = codex_dirs
     raw["pi_output_dirs"] = pi_dirs
     return raw
@@ -187,18 +221,24 @@ def resolve_plugin_conversion_path(
     plugin_config: PluginConfig,
     installed: claude.InstalledPlugin | None,
 ) -> Path | None:
+    """Resolve the configured source authority, using installed state only as fallback.
+
+    A configured local marketplace remains authoritative after Claude installs a cached copy.
+    Remote and marketplace-less plugins depend on Claude's installed source instead.
+    """
+    marketplace_name = plugin_config.marketplace
+    marketplace = (
+        config.marketplaces.get(marketplace_name) if marketplace_name is not None else None
+    )
+    if marketplace is not None and marketplace.source == PluginSource.LOCAL:
+        return resolve_local_marketplace_plugin_path(
+            Path(marketplace.path), plugin_config.plugin_name
+        )
+
     installed_path = (
         Path(installed.install_path) if installed is not None and installed.install_path else None
     )
-    if installed_path is not None and installed_path.is_dir():
-        return installed_path
-    marketplace_name = plugin_config.marketplace
-    if marketplace_name is None:
-        return installed_path
-    marketplace = config.marketplaces.get(marketplace_name)
-    if marketplace is None or marketplace.source != PluginSource.LOCAL:
-        return installed_path
-    return resolve_local_marketplace_plugin_path(Path(marketplace.path), plugin_config.plugin_name)
+    return installed_path if installed_path is not None and installed_path.is_dir() else None
 
 
 def compute_owned_codex_hash(spec: CodexPackageSpec) -> str | None:

--- a/tests/probes/probe_ai_config_sync_codex.py
+++ b/tests/probes/probe_ai_config_sync_codex.py
@@ -246,11 +246,26 @@ def probe(codex: str) -> dict[str, object]:
         output = root / "output"
         marketplace = root / "claude-marketplace"
         plugin = marketplace / "dev-tools"
+        installed_plugin = root / "claude-cache" / "dev-tools"
         config = root / "config.yaml"
         bin_dir = root / "bin"
         codex_home.mkdir(parents=True)
         bin_dir.mkdir()
         shutil.copytree(source_fixture, plugin)
+        local_skill = plugin / "skills/code-review/SKILL.md"
+        local_skill.write_text(
+            local_skill.read_text().replace(
+                "description: Review code for best practices, security issues, and style violations.",
+                "description: Review code for best practices, security issues, and style violations. LOCAL_AUTHORITY_MARKER.",
+            )
+        )
+        shutil.copytree(plugin, installed_plugin)
+        installed_skill = installed_plugin / "skills/code-review/SKILL.md"
+        installed_skill.write_text(
+            installed_skill.read_text().replace(
+                "LOCAL_AUTHORITY_MARKER", "STALE_INSTALLED_COPY_MARKER"
+            )
+        )
         (marketplace / ".claude-plugin").mkdir()
         (marketplace / ".claude-plugin/marketplace.json").write_text(
             json.dumps(
@@ -260,7 +275,7 @@ def probe(codex: str) -> dict[str, object]:
                 }
             )
         )
-        _write_fake_claude(bin_dir / "claude", plugin, marketplace)
+        _write_fake_claude(bin_dir / "claude", installed_plugin, marketplace)
         _write_config(config, marketplace, output, enabled=True)
         (codex_home / "config.toml").write_text('model = "preserve-public-sync"\n')
 
@@ -301,10 +316,20 @@ def probe(codex: str) -> dict[str, object]:
         else:
             raise AssertionError(f"unsupported Codex public-sync probe version: {version_output}")
 
-        first = _actions(_run_ai_config(config, env))
+        first_payload = _run_ai_config(config, env, "--force", "--verify")
+        first = _actions(first_payload)
         if not {"register_codex_marketplace", "install_codex_plugin"} <= set(first):
             raise AssertionError(f"first public sync actions were incomplete: {first}")
+        verification = first_payload.get("verification")
+        if not isinstance(verification, dict) or verification.get("performed") is not True:
+            raise AssertionError(f"first public sync did not perform verification: {verification}")
+        if verification.get("discrepancies") != []:
+            raise AssertionError(f"first public sync reported false drift: {verification}")
         _assert_prompt_marker(codex, env, output, "dev-tools:code-review")
+        _assert_prompt_marker(codex, env, output, "LOCAL_AUTHORITY_MARKER")
+        prompt = run(codex, ["-C", str(output), "debug", "prompt-input", "probe"], env).stdout
+        if "STALE_INSTALLED_COPY_MARKER" in prompt:
+            raise AssertionError("public sync converted Claude's stale installed copy")
 
         unchanged = _actions(_run_ai_config(config, env))
         if set(unchanged) != {"noop_codex_plugin"}:
@@ -332,7 +357,7 @@ def probe(codex: str) -> dict[str, object]:
         skill_path = plugin / "skills/code-review/SKILL.md"
         skill_path.write_text(
             skill_path.read_text().replace(
-                "description: Review code for best practices, security issues, and style violations.",
+                "description: Review code for best practices, security issues, and style violations. LOCAL_AUTHORITY_MARKER.",
                 "description: PUBLIC_SYNC_UPDATE_MARKER.",
             )
         )
@@ -402,7 +427,7 @@ def probe(codex: str) -> dict[str, object]:
         "binary": str(Path(codex).resolve()),
         "public_command": f"{sys.executable} -m ai_config sync --config <isolated> --json",
         "lifecycle": [
-            "first-sync-register-install",
+            "first-sync-force-verify-local-authority",
             "unchanged-noop",
             "generated-output-integrity-repair",
             "source-refresh-update",

--- a/tests/unit/converters/test_shared_skill_resources.py
+++ b/tests/unit/converters/test_shared_skill_resources.py
@@ -499,8 +499,9 @@ def test_hash_includes_shared_bytes_and_fails_closed_on_symlink(tmp_path: Path) 
     assert compute_plugin_hash(plugin) is None
 
 
-def test_cache_v7_is_invalidated_for_complete_source_hashing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("legacy_version", [7, 8])
+def test_legacy_cache_entries_are_invalidated_for_logical_source_identity(
+    legacy_version: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     cache = tmp_path / ".ai-config/cache/conversion-hashes.json"
@@ -508,7 +509,7 @@ def test_cache_v7_is_invalidated_for_complete_source_hashing(
     cache.write_text(
         json.dumps(
             {
-                "version": 7,
+                "version": legacy_version,
                 "entries": {"old": {}},
                 "codex_output_dirs": ["/custom/codex"],
                 "pi_output_dirs": ["/custom/pi"],
@@ -517,14 +518,34 @@ def test_cache_v7_is_invalidated_for_complete_source_hashing(
     )
     loaded = load_conversion_cache()
     assert loaded == {
-        "version": 8,
+        "version": 9,
         "entries": {},
         "codex_output_dirs": ["/custom/codex"],
         "pi_output_dirs": ["/custom/pi"],
     }
 
 
-@pytest.mark.parametrize("version", [7, 8])
+def test_cache_v9_rejects_malformed_logical_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".ai-config/cache/conversion-hashes.json"
+    cache.parent.mkdir(parents=True)
+    cache.write_text(
+        json.dumps(
+            {
+                "version": 9,
+                "entries": {"demo@market": {"not-json": {"hash": "digest"}}},
+                "codex_output_dirs": [],
+                "pi_output_dirs": [],
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="Invalid conversion cache entries"):
+        load_conversion_cache()
+
+
+@pytest.mark.parametrize("version", [7, 8, 9])
 @pytest.mark.parametrize("invalid_root", ["relative/root", "~ai_config_no_such_user/root"])
 def test_cache_rejects_nonabsolute_or_unexpandable_output_roots(
     version: int,
@@ -549,7 +570,7 @@ def test_cache_rejects_nonabsolute_or_unexpandable_output_roots(
         load_conversion_cache()
 
 
-@pytest.mark.parametrize("version", [7, 8])
+@pytest.mark.parametrize("version", [7, 8, 9])
 def test_cache_rejects_symlink_loop_output_root(
     version: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -574,7 +595,7 @@ def test_cache_rejects_symlink_loop_output_root(
         load_conversion_cache()
 
 
-@pytest.mark.parametrize("version", [7, 8])
+@pytest.mark.parametrize("version", [7, 8, 9])
 def test_cache_normalizes_and_deduplicates_preserved_output_roots(
     version: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -66,8 +66,11 @@ def test_pi_cli_verify_and_json_report_no_false_drift(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Drive sync/status verification through Click with actual Pi output and only CLI inventory patched."""
-    source = tmp_path / "source"
+    marketplace = tmp_path / "marketplace"
+    source = marketplace / "dev-tools"
     shutil.copytree(Path(__file__).parents[1] / "fixtures/sample-plugins/complete-plugin", source)
+    installed_source = tmp_path / "installed-cache" / "dev-tools"
+    shutil.copytree(source, installed_source)
     output = tmp_path / "output"
     config = tmp_path / "config.yaml"
     config.write_text(
@@ -79,7 +82,7 @@ def test_pi_cli_verify_and_json_report_no_false_drift(
               marketplaces:
                 local:
                   source: local
-                  path: {source}
+                  path: {marketplace}
               plugins:
                 - id: dev-tools@local
                   scope: project
@@ -91,13 +94,13 @@ def test_pi_cli_verify_and_json_report_no_false_drift(
         """)
     )
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
-    installed = [InstalledPlugin("dev-tools@local", "1", "project", True, str(source))]
+    installed = [InstalledPlugin("dev-tools@local", "1", "project", True, str(installed_source))]
     with (
         patch("ai_config.operations.claude.list_installed_plugins", return_value=(installed, [])),
         patch(
             "ai_config.operations.claude.list_installed_marketplaces",
             return_value=(
-                [InstalledMarketplace("local", PluginSource.LOCAL, "", str(source))],
+                [InstalledMarketplace("local", PluginSource.LOCAL, "", str(marketplace))],
                 [],
             ),
         ),
@@ -199,6 +202,39 @@ class TestSyncCommand:
             "remove_codex_marketplace"
         ]
         assert payload["planned_actions"] == []
+
+    def test_sync_text_skips_verification_after_apply_failure(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        sync_result = SyncResult(success=False, errors=["apply failed"])
+        with (
+            patch("ai_config.cli.sync_config", return_value={"claude": sync_result}),
+            patch("ai_config.cli.verify_sync") as verify,
+        ):
+            result = runner.invoke(main, ["sync", "-c", str(config_file), "--verify"])
+
+        assert result.exit_code == 1
+        assert "apply failed" in result.output
+        verify.assert_not_called()
+
+    def test_sync_json_skips_verification_after_apply_failure(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        sync_result = SyncResult(success=False, errors=["apply failed"])
+        with (
+            patch("ai_config.cli.sync_config", return_value={"claude": sync_result}),
+            patch("ai_config.cli.verify_sync") as verify,
+        ):
+            result = runner.invoke(main, ["sync", "-c", str(config_file), "--verify", "--json"])
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["verification"] == {
+            "requested": True,
+            "performed": False,
+            "discrepancies": [],
+        }
+        verify.assert_not_called()
 
     def test_sync_with_errors(self, runner: CliRunner, config_file: Path) -> None:
         """Shows errors from sync."""

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -861,8 +861,10 @@ class TestSyncTarget:
             assert call_args["output_dir"] == Path(tmp_path / "home")
             assert isolate_codex_lifecycle.call_count == 2
 
-    def test_sync_skips_conversion_when_hash_unchanged(
+    @pytest.mark.parametrize("same_source_path", [True, False])
+    def test_sync_cache_requires_matching_logical_source_observations(
         self,
+        same_source_path: bool,
         mock_installed_plugins: list[InstalledPlugin],
         mock_installed_marketplaces: list[InstalledMarketplace],
         monkeypatch: pytest.MonkeyPatch,
@@ -892,9 +894,13 @@ class TestSyncTarget:
         cache = {
             "version": _CONVERSION_CACHE_VERSION,
             "entries": {
-                str(plugin_path): {
+                "plugin1@my-marketplace": {
                     signature: {
                         "hash": "abc123",
+                        "source_path": str(
+                            plugin_path if same_source_path else tmp_path / "previous-source"
+                        ),
+                        "source_provenance": "installed_plugin",
                         "codex_output_hash": "generated123",
                     },
                 }
@@ -921,7 +927,10 @@ class TestSyncTarget:
             result = sync_target(target)
 
             assert result.success is True
-            mock_convert.assert_not_called()
+            if same_source_path:
+                mock_convert.assert_not_called()
+            else:
+                mock_convert.assert_called()
 
     def test_sync_force_convert_ignores_cache(
         self,
@@ -1038,19 +1047,25 @@ class TestSyncTarget:
             assert result.success is True
             assert saved_cache["codex_output_dirs"] == [str(output_dir.resolve())]
             assert "entries" in saved_cache
-            assert str(plugin_path) in saved_cache["entries"]
-            assert signature in saved_cache["entries"][str(plugin_path)]
+            assert "plugin1@my-marketplace" in saved_cache["entries"]
+            entry = saved_cache["entries"]["plugin1@my-marketplace"][signature]
+            assert entry["source_path"] == str(plugin_path)
 
-    def test_sync_conversion_uses_local_marketplace_when_install_path_missing(
+    def test_sync_conversion_keeps_configured_local_marketplace_authoritative(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """Conversion falls back to local marketplace source when Claude cache path is stale."""
+        """Configured local source stays authoritative after Claude installs a cached copy."""
         plugin_dir = tmp_path / "marketplace" / "plugin1"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / ".claude-plugin").mkdir()
         (plugin_dir / ".claude-plugin" / "plugin.json").write_text('{"name":"plugin1"}')
+        installed_cache = tmp_path / "installed-cache"
+        (installed_cache / ".claude-plugin").mkdir(parents=True)
+        (installed_cache / ".claude-plugin/plugin.json").write_text(
+            '{"name":"plugin1","description":"stale installed copy"}'
+        )
         conversion = ConversionConfig(
             enabled=True,
             targets=("pi",),
@@ -1074,7 +1089,7 @@ class TestSyncTarget:
                 version="1.0.0",
                 scope="user",
                 enabled=True,
-                install_path=str(tmp_path / "missing-cache"),
+                install_path=str(installed_cache),
             )
         ]
 
@@ -1296,7 +1311,17 @@ class TestSyncTarget:
             ),
             patch(
                 "ai_config.operations.claude.list_installed_marketplaces",
-                return_value=([], []),
+                return_value=(
+                    [
+                        InstalledMarketplace(
+                            name="my-marketplace",
+                            source=PluginSource.LOCAL,
+                            repo=str(tmp_path / "marketplace"),
+                            install_location=str(tmp_path / "marketplace"),
+                        )
+                    ],
+                    [],
+                ),
             ),
             patch(
                 "ai_config.sync_state.load_conversion_cache",
@@ -1542,12 +1567,13 @@ class TestSyncTarget:
             patch(
                 "ai_config.operations.claude.install_plugin",
                 return_value=CommandResult(True, "", "", 0),
-            ),
+            ) as install,
         ):
             result = sync_target(target)
 
         assert result.success is False
-        assert any("temporarily unavailable" in error for error in result.errors)
+        assert any("prerequisites did not converge" in error for error in result.errors)
+        install.assert_called_once_with("missing-plugin@market", "user")
         retained = isolate_codex_lifecycle.call_args.kwargs["retained_plugin_ids"]
         assert retained == {"missing-plugin@ai-config-missing-plugin"}
 
@@ -1671,8 +1697,13 @@ class TestSyncTarget:
         cache = {
             "version": _CONVERSION_CACHE_VERSION,
             "entries": {
-                str(plugin_path): {
-                    signature: {"hash": "abc123", "codex_output_hash": "generated123"}
+                "plugin1@my-marketplace": {
+                    signature: {
+                        "hash": "abc123",
+                        "source_path": str(plugin_path),
+                        "source_provenance": "installed_plugin",
+                        "codex_output_hash": "generated123",
+                    }
                 }
             },
         }

--- a/tests/unit/test_sync_pipeline.py
+++ b/tests/unit/test_sync_pipeline.py
@@ -339,6 +339,52 @@ def test_remote_source_converges_after_one_bounded_reobservation(tmp_path: Path)
     install.assert_called_once_with("demo@remote", "user")
 
 
+def test_remote_prerequisite_runs_before_unrelated_conversion_blocker(
+    tmp_path: Path,
+) -> None:
+    malformed = tmp_path / "malformed-plugin"
+    (malformed / ".claude-plugin").mkdir(parents=True)
+    (malformed / ".claude-plugin/plugin.json").write_text("{not-json")
+    deferred = tmp_path / "deferred-plugin"
+    (deferred / ".claude-plugin").mkdir(parents=True)
+    (deferred / ".claude-plugin/plugin.json").write_text('{"name":"deferred","version":"1.0.0"}')
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            marketplaces={"remote": MarketplaceConfig(PluginSource.GITHUB, repo="owner/plugins")},
+            plugins=(PluginConfig("malformed@remote"), PluginConfig("deferred@remote")),
+            conversion=ConversionConfig(targets=("cursor",), output_dir=str(tmp_path / "output")),
+        ),
+    )
+    marketplace = InstalledMarketplace("remote", PluginSource.GITHUB, "owner/plugins", "")
+    malformed_installed = InstalledPlugin("malformed@remote", "1.0.0", "user", True, str(malformed))
+    deferred_installed = InstalledPlugin("deferred@remote", "1.0.0", "user", True, str(deferred))
+    cache = {"version": 9, "entries": {}, "codex_output_dirs": [], "pi_output_dirs": []}
+    command = CommandResult(True, "", "", 0)
+    with (
+        patch(
+            "ai_config.operations.claude.list_installed_marketplaces",
+            return_value=([marketplace], []),
+        ),
+        patch(
+            "ai_config.operations.claude.list_installed_plugins",
+            side_effect=[
+                ([malformed_installed], []),
+                ([malformed_installed], []),
+                ([malformed_installed, deferred_installed], []),
+            ],
+        ),
+        patch("ai_config.sync_state.load_conversion_cache", return_value=cache),
+        patch("ai_config.operations.claude.install_plugin", return_value=command) as install,
+    ):
+        result = sync_target(target)
+
+    assert not result.success
+    assert [action.action for action in result.actions_taken] == ["install"]
+    assert any("Conversion failed for malformed@remote" in error for error in result.errors)
+    install.assert_called_once_with("deferred@remote", "user")
+
+
 def test_deferred_remote_dry_run_reports_only_exact_prerequisite_actions(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_sync_pipeline.py
+++ b/tests/unit/test_sync_pipeline.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from ai_config.adapters.claude import CommandResult, InstalledMarketplace, InstalledPlugin
-from ai_config.operations import apply_sync_plan, build_sync_plan
+from ai_config.operations import apply_sync_plan, build_sync_plan, sync_target
 from ai_config.sync_pipeline import (
     CacheOwnershipSnapshot,
     DesiredState,
@@ -295,6 +295,137 @@ def test_unavailable_conversion_source_allows_planned_plugin_install() -> None:
     assert [item.action for item in report.completed] == ["install"]
     assert any("temporarily unavailable" in error for error in report.errors)
     install.assert_called_once_with("demo", "user")
+
+
+def test_remote_source_converges_after_one_bounded_reobservation(tmp_path: Path) -> None:
+    source = tmp_path / "installed-plugin"
+    (source / ".claude-plugin").mkdir(parents=True)
+    (source / ".claude-plugin/plugin.json").write_text('{"name":"demo","version":"1.0.0"}')
+    (source / "skills/demo").mkdir(parents=True)
+    (source / "skills/demo/SKILL.md").write_text("---\nname: demo\n---\nBody\n")
+    output = tmp_path / "output"
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            marketplaces={"remote": MarketplaceConfig(PluginSource.GITHUB, repo="owner/plugins")},
+            plugins=(PluginConfig("demo@remote"),),
+            conversion=ConversionConfig(targets=("cursor",), output_dir=str(output)),
+        ),
+    )
+    marketplace = InstalledMarketplace(
+        "remote", PluginSource.GITHUB, "owner/plugins", str(tmp_path / "marketplace")
+    )
+    installed = InstalledPlugin("demo@remote", "1.0.0", "user", True, str(source))
+    cache = {"version": 9, "entries": {}, "codex_output_dirs": [], "pi_output_dirs": []}
+    command = CommandResult(True, "", "", 0)
+    with (
+        patch(
+            "ai_config.operations.claude.list_installed_marketplaces",
+            return_value=([marketplace], []),
+        ),
+        patch(
+            "ai_config.operations.claude.list_installed_plugins",
+            side_effect=[([], []), ([], []), ([installed], []), ([installed], [])],
+        ),
+        patch("ai_config.sync_state.load_conversion_cache", return_value=cache),
+        patch("ai_config.operations.claude.install_plugin", return_value=command) as install,
+        patch("ai_config.sync_state.save_conversion_cache"),
+    ):
+        result = sync_target(target)
+
+    assert result.success
+    assert [action.action for action in result.actions_taken][0] == "install"
+    assert (output / ".cursor/skills/demo-demo/SKILL.md").is_file()
+    install.assert_called_once_with("demo@remote", "user")
+
+
+def test_deferred_remote_dry_run_reports_only_exact_prerequisite_actions(
+    tmp_path: Path,
+) -> None:
+    available = tmp_path / "available"
+    (available / ".claude-plugin").mkdir(parents=True)
+    (available / ".claude-plugin/plugin.json").write_text('{"name":"available","version":"1.0.0"}')
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            marketplaces={"remote": MarketplaceConfig(PluginSource.GITHUB, repo="owner/plugins")},
+            plugins=(PluginConfig("available@remote"), PluginConfig("deferred@remote")),
+            conversion=ConversionConfig(targets=("cursor",), output_dir=str(tmp_path / "output")),
+        ),
+    )
+    marketplace = InstalledMarketplace("remote", PluginSource.GITHUB, "owner/plugins", "")
+    installed = InstalledPlugin("available@remote", "1.0.0", "user", True, str(available))
+    cache = {"version": 9, "entries": {}, "codex_output_dirs": [], "pi_output_dirs": []}
+    with (
+        patch(
+            "ai_config.operations.claude.list_installed_marketplaces",
+            return_value=([marketplace], []),
+        ),
+        patch(
+            "ai_config.operations.claude.list_installed_plugins",
+            return_value=([installed], []),
+        ),
+        patch("ai_config.sync_state.load_conversion_cache", return_value=cache),
+    ):
+        result = sync_target(target, dry_run=True)
+
+    assert not result.success
+    assert [action.action for action in result.actions_taken] == ["install"]
+    assert result.actions_taken[0].target == "deferred@remote"
+    assert any("temporarily unavailable" in error for error in result.errors)
+
+
+def test_missing_configured_local_source_never_triggers_reobservation(tmp_path: Path) -> None:
+    marketplace_root = tmp_path / "local-marketplace"
+    marketplace_root.mkdir()
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            marketplaces={
+                "local": MarketplaceConfig(PluginSource.LOCAL, path=str(marketplace_root))
+            },
+            plugins=(PluginConfig("demo@local"),),
+            conversion=ConversionConfig(targets=("cursor",), output_dir=str(tmp_path / "output")),
+        ),
+    )
+    marketplace = InstalledMarketplace("local", PluginSource.LOCAL, "", str(marketplace_root))
+    command = CommandResult(True, "", "", 0)
+    cache = {"version": 9, "entries": {}, "codex_output_dirs": [], "pi_output_dirs": []}
+    with (
+        patch(
+            "ai_config.operations.claude.list_installed_marketplaces",
+            return_value=([marketplace], []),
+        ),
+        patch(
+            "ai_config.operations.claude.list_installed_plugins", return_value=([], [])
+        ) as observe_plugins,
+        patch("ai_config.sync_state.load_conversion_cache", return_value=cache),
+        patch("ai_config.operations.claude.install_plugin", return_value=command) as install,
+    ):
+        result = sync_target(target)
+
+    assert not result.success
+    assert any("temporarily unavailable" in error for error in result.errors)
+    assert observe_plugins.call_count == 2
+    install.assert_called_once_with("demo@local", "user")
+
+
+def test_duplicate_configured_selectors_block_before_mutation() -> None:
+    target = TargetConfig(
+        type="claude",
+        config=ClaudeTargetConfig(
+            plugins=(PluginConfig("demo"), PluginConfig("demo")),
+        ),
+    )
+    with (
+        patch("ai_config.operations.claude.list_installed_marketplaces", return_value=([], [])),
+        patch("ai_config.operations.claude.list_installed_plugins", return_value=([], [])),
+        patch("ai_config.operations.claude.install_plugin") as install,
+    ):
+        report = apply_sync_plan(build_sync_plan(target))
+
+    assert report.errors == ("Duplicate configured plugin selectors: demo",)
+    install.assert_not_called()
 
 
 def test_cache_checkpoint_failure_is_reported_and_not_committed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

A fresh isolated `sync --force --verify` could generate and install every Codex package successfully, then falsely report that all packages needed another refresh. Source resolution changed from a configured local marketplace to Claude's installed cache after apply, while conversion cache identity depended on that incidental path. Fresh remote plugins also needed a second invocation before conversion could inspect their installed source.

## What changed

- Configured local marketplaces are now strict conversion-source authorities. Remote and marketplace-less plugins may use safely observed installed sources.
- Conversion cache v9 uses the configured plugin selector and conversion signature as logical identity. Source provenance, path, source digest, and generated Codex digest remain required cache-hit observations; migration discards legacy content entries but preserves validated ownership roots.
- Sync may apply one immutable Claude prerequisite plan, re-observe once, and apply one conversion-only plan. It blocks if Claude prerequisites still have not converged and never replans inside an executor or recursively syncs until quiet.
- The prerequisite projection excludes conversion-only blockers, so an unrelated malformed readable source cannot prevent a required Claude install. The re-observed conversion stage still reports that failure before target mutation.
- Dry-run reports only observable prerequisite work for deferred remote sources. Text and JSON verification run only after every apply stage succeeds.
- ADR 0008, the specification, architecture, command reference, conversion guide, and changelog define the new bounded convergence contract.

**Change shape:** 754 Git textual changed-line events.
Counts are additions plus deletions, so modified lines can count twice. They describe diff shape, not effort, risk, quality, review time, or readiness.

| Conceptual group | Additions | Deletions | Changed-line events |
| --- | ---: | ---: | ---: |
| Bounded staged convergence | 162 | 6 | 168 |
| Source authority and cache identity | 78 | 27 | 105 |
| Verification interface | 13 | 4 | 17 |
| Published contract navigation | 1 | 0 | 1 |
| Supporting changes | 411 | 52 | 463 |
| **Total** | **665** | **89** | **754** |

<details>
<summary>Core changes: 291 changed-line events across 7 files</summary>

| Conceptual group | File | Additions | Deletions | Changed-line events |
| --- | --- | ---: | ---: | ---: |
| Bounded staged convergence | <code>src/ai_config/sync_pipeline.py</code> | 72 | 1 | 73 |
| Bounded staged convergence | <code>src/ai_config/sync_orchestration.py</code> | 68 | 3 | 71 |
| Bounded staged convergence | <code>src/ai_config/operations.py</code> | 22 | 2 | 24 |
| **Bounded staged convergence total** | **3 files** | **162** | **6** | **168** |
| Source authority and cache identity | <code>src/ai_config/sync_state.py</code> | 54 | 14 | 68 |
| Source authority and cache identity | <code>src/ai_config/sync_conversion.py</code> | 24 | 13 | 37 |
| **Source authority and cache identity total** | **2 files** | **78** | **27** | **105** |
| Verification interface | <code>src/ai_config/cli.py</code> | 13 | 4 | 17 |
| **Verification interface total** | **1 file** | **13** | **4** | **17** |
| Published contract navigation | <code>mkdocs.yml</code> | 1 | 0 | 1 |
| **Published contract navigation total** | **1 file** | **1** | **0** | **1** |

</details>

<details>
<summary>Supporting changes: 463 changed-line events across 15 files</summary>

| Supporting kind | Files | Additions | Deletions | Changed-line events |
| --- | ---: | ---: | ---: | ---: |
| test | 6 | 326 | 32 | 358 |
| docs | 9 | 85 | 20 | 105 |

#### Supporting files

| Supporting kind | File | Additions | Deletions | Changed-line events |
| --- | --- | ---: | ---: | ---: |
| test | <code>tests/unit/test_sync_pipeline.py</code> | 178 | 1 | 179 |
| test | <code>tests/unit/test_operations.py</code> | 44 | 13 | 57 |
| test | <code>tests/unit/test_cli.py</code> | 40 | 4 | 44 |
| test | <code>tests/unit/converters/test_shared_skill_resources.py</code> | 28 | 7 | 35 |
| test | <code>tests/probes/probe_ai_config_sync_codex.py</code> | 29 | 4 | 33 |
| test | <code>SPEC.md</code> | 7 | 3 | 10 |
| **test total** | **6 files** | **326** | **32** | **358** |
| docs | <code>docs/conversion.md</code> | 25 | 10 | 35 |
| docs | <code>docs/adr/0008-bounded-sync-convergence-stages.md</code> | 34 | 0 | 34 |
| docs | <code>CHANGELOG.md</code> | 14 | 4 | 18 |
| docs | <code>docs/architecture.md</code> | 4 | 2 | 6 |
| docs | <code>README.md</code> | 2 | 2 | 4 |
| docs | <code>docs/adr/0006-observe-plan-apply-sync.md</code> | 3 | 1 | 4 |
| docs | <code>docs/commands.md</code> | 1 | 1 | 2 |
| docs | <code>docs/AGENTS.md</code> | 1 | 0 | 1 |
| docs | <code>docs/adr/README.md</code> | 1 | 0 | 1 |
| **docs total** | **9 files** | **85** | **20** | **105** |

</details>

## Evidence

- **Changed sync contracts pass focused regression coverage.** Source authority, cache migration and hit observations, bounded remote re-observation, prerequisite progress despite unrelated conversion failures, conversion-only stage projection, dry-run deferral, duplicate-selector rejection, and verification gating passed 186 focused tests with one expected platform skip.
- **The real Codex lifecycle converges in isolation.** The public probe passed against Codex 0.145 with a temporary home, force-plus-verify, a deliberately stale Claude installed copy, generated-output repair, owned removal, and unrelated-state preservation.
- **Static and published contracts are consistent.** Ruff, ty, and strict MkDocs passed; an independent architecture review's source-authority, cache-observation, and stage-authorization blockers were addressed.
- **GitHub's clean runners passed the complete suite.** Code quality checks, all-tools E2E, the latest Codex package probe, and the strict documentation build are green. One transient rerun was needed because the first code-quality container could not find Pi; the unchanged rerun passed.
- **The full Dots canary remains deliberately separate.** After this lands, the merged release will be installed and the isolated all-plugin Dots sync will drive a Dots-owned follow-up PR for any plugin-input or guidance changes.
